### PR TITLE
Add stats editor in sidebar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
-# Ignore data directory
-data/
+# Ignore data directory but keep stats placeholder
+data/*
+!data/stats/
+!data/stats/.gitkeep
 
 # Ignore temporary files
 *.tmp


### PR DESCRIPTION
## Summary
- Add sortable stats table and inputs to the collapsible sidebar
- Persist monthly stats to `data/stats/<year>.json`
- Sync sidebar period with main calendar navigation

## Testing
- `python -m py_compile app/main.py`
- `python - <<'PY'
import app.main
print('loaded')
PY` *(fails: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68af3d34541c83329554fbad1f7c7b43