### PR TITLE
Add release schedule dialog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 data/*
 !data/stats/
 !data/stats/.gitkeep
+!data/release/
+!data/release/.gitkeep
 
 # Ignore temporary files
 *.tmp


### PR DESCRIPTION
## Summary
- add `ReleaseDialog` to edit release schedule data and store it per month
- open release dialog from the "Выкладка" button in sidebar
- persist release files under `data/release/<year>-<month>.json`

## Testing
- `python -m py_compile app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68af3e73430c83329d7b8686426bea89