### PR TITLE
Add yearly statistics dialog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ data/*
 !data/stats/.gitkeep
 !data/release/
 !data/release/.gitkeep
+!data/year/
+!data/year/.gitkeep
 
 # Ignore temporary files
 *.tmp


### PR DESCRIPTION
## Summary
- Implement YearStatsDialog for month-by-indicator tables with yearly totals
- Allow manual entry of commission and software costs with auto-calculated net values
- Save per-year data to `data/year/<year>.json` and open dialog via sidebar

## Testing
- `python -m py_compile app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68af424c749483328d8c12315f4555e2