### PR TITLE
Add period top aggregators and report storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ data/*
 !data/release/.gitkeep
 !data/year/
 !data/year/.gitkeep
+!data/top/
+!data/top/.gitkeep
 
 # Ignore temporary files
 *.tmp


### PR DESCRIPTION
## Summary
- add TopDialog to aggregate stats by month, quarter, half-year or year
- save generated rankings under `data/top/<year>.json`
- hook new sidebar buttons to open period-based top reports

## Testing
- `python -m py_compile app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_68af4418d4e08332a930b068f6d469db