### PR TITLE
Improve disabled calendar day styling

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -974,7 +974,12 @@ class ExcelCalendarTable(QtWidgets.QTableWidget):
                 self.cell_tables[(r, c)] = inner
                 if day.month != month:
                     container.setEnabled(False)
+                    container.setStyleSheet("background-color:#2a2a2a; color:#777;")
+                    lbl.setStyleSheet("color:#777;")
                 else:
+                    container.setEnabled(True)
+                    container.setStyleSheet("")
+                    lbl.setStyleSheet("")
                     rows = md.days.get(day.day, [])
                     for rr, row in enumerate(rows):
                         if rr >= inner.rowCount():


### PR DESCRIPTION
## Summary
- Grey out cells belonging to other months and soften date label color
- Clear container and label styles when displaying current month

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aff12038c48332a150d000a5dc0782