### PR TITLE
Center day labels in month view

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -966,7 +966,7 @@ class ExcelCalendarTable(QtWidgets.QTableWidget):
                 lay = QtWidgets.QVBoxLayout(container)
                 lay.setContentsMargins(0, 0, 0, 0)
                 lbl = QtWidgets.QLabel(str(day.day), container)
-                lay.addWidget(lbl, alignment=QtCore.Qt.AlignLeft)
+                lay.addWidget(lbl, alignment=QtCore.Qt.AlignHCenter | QtCore.Qt.AlignTop)
                 inner = self._create_inner_table()
                 lay.addWidget(inner)
                 self.setCellWidget(r, c, container)


### PR DESCRIPTION
## Summary
- center calendar day numbers within cells and align them to the top so nested tables remain beneath

## Testing
- `python -m py_compile app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68aff20843ec83328df64bd8dd0a3bf6