### PR TITLE
Add configurable day row count

### DIFF
--- a/data/config.json
+++ b/data/config.json
@@ -2,5 +2,6 @@
   "neon": false,
   "header_font": "Arial",
   "text_font": "Arial",
+  "day_rows": 6,
   "save_path": "."
 }


### PR DESCRIPTION
## Summary
- make day row count configurable via `day_rows` setting
- allow editing day rows in settings dialog
- rebuild inner tables when `day_rows` changes

## Testing
- `pytest`
- `python -m py_compile app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68aff2a27adc8332953133f708b24cc0