### PR TITLE
Remove unused Cyrillic label from status bar

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1453,8 +1453,6 @@ class MainWindow(QtWidgets.QMainWindow):
         self.setStatusBar(bar)
         self.lbl_timer = QtWidgets.QLabel("000:00:00:00", self)
         bar.addWidget(self.lbl_timer)
-        self.lbl_cyrillic = QtWidgets.QLabel("Пример кириллицы", self)
-        bar.addWidget(self.lbl_cyrillic)
         self.lbl_version = QtWidgets.QLabel("", self)
         bar.addPermanentWidget(self.lbl_version)
         self._timer = QtCore.QTimer(self)


### PR DESCRIPTION
## Summary
- drop leftover "Пример кириллицы" label from the status bar so only timer and version remain

## Testing
- `python -m py_compile app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68af328649d08332b9930cbc3a964067