### PR TITLE
Block accent combo signals during initialization

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1212,7 +1212,9 @@ class SettingsDialog(QtWidgets.QDialog):
             (i for i, (_, c) in enumerate(self._preset_colors) if c.name().lower() == current),
             other_index,
         )
+        self.combo_accent.blockSignals(True)
         self.combo_accent.setCurrentIndex(idx)
+        self.combo_accent.blockSignals(False)
         if idx == other_index:
             pix = QtGui.QPixmap(16, 16)
             pix.fill(self._accent_color)


### PR DESCRIPTION
## Summary
- prevent `_on_accent_changed` from firing during `SettingsDialog` initialization by blocking `combo_accent` signals while setting the initial index

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b0a9e0ebb08332a728ba43e41d6894