### PR TITLE
Remove table-level event filters from ReleaseDialog

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -207,7 +207,6 @@ class ReleaseDialog(QtWidgets.QDialog):
         self.table.horizontalHeader().setStretchLastSection(True)
         self.table.verticalHeader().setVisible(False)
         self.table.setRowCount(self.days_in_month)
-        self.table.installEventFilter(NeonEventFilter(self.table))
 
         app = QtWidgets.QApplication.instance()
         self.setFont(app.font())
@@ -257,8 +256,6 @@ class ReleaseDialog(QtWidgets.QDialog):
         box.accepted.connect(self.save)
         box.rejected.connect(self.reject)
         lay.addWidget(box)
-        btn_save.installEventFilter(NeonEventFilter(btn_save))
-        btn_close.installEventFilter(NeonEventFilter(btn_close))
 
         self.load()
 


### PR DESCRIPTION
## Summary
- Drop the global event filter from the release table and buttons.
- Keep Neon event filters on inner QSpinBox, QComboBox and QTimeEdit widgets only.

## Testing
- `python -m py_compile app/main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b0c79501d483328b8074f8a56f7b81