### PR TITLE
Enable hover leave handling for sidebar buttons

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -125,7 +125,7 @@ class NeonEventFilter(QtCore.QObject):
     def eventFilter(self, obj, ev):
         if ev.type() in (QtCore.QEvent.Enter, QtCore.QEvent.FocusIn):
             apply_neon_effect(self._widget, True)
-        elif ev.type() in (QtCore.QEvent.Leave, QtCore.QEvent.FocusOut):
+        elif ev.type() in (QtCore.QEvent.Leave, QtCore.QEvent.FocusOut, QtCore.QEvent.HoverLeave):
             apply_neon_effect(self._widget, False)
         return False
 
@@ -1218,6 +1218,7 @@ class CollapsibleSidebar(QtWidgets.QFrame):
             b.setToolButtonStyle(QtCore.Qt.ToolButtonTextBesideIcon)
             b.setCursor(QtCore.Qt.PointingHandCursor)
             b.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed)
+            b.setAttribute(QtCore.Qt.WA_Hover, True)
             lay.addWidget(b); self.buttons.append(b)
             b.installEventFilter(NeonEventFilter(b))
             if label == "Вводные":


### PR DESCRIPTION
## Summary
- enable hover events on collapsible sidebar buttons by setting `WA_Hover`
- disable neon highlight when hover leaves via `HoverLeave` event handling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b0c84d601c8332ae9a29c420e469c0