### PR TITLE
Clear neon on widget leave

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1018,7 +1018,11 @@ class NeonTableWidget(QtWidgets.QTableWidget):
         return super().event(ev)
 
     def eventFilter(self, obj, ev):
-        if ev.type() in (QtCore.QEvent.HoverLeave, QtCore.QEvent.FocusOut):
+        if ev.type() in (
+            QtCore.QEvent.HoverLeave,
+            QtCore.QEvent.Leave,
+            QtCore.QEvent.FocusOut,
+        ):
             self._clear_neon()
         return super().eventFilter(obj, ev)
 


### PR DESCRIPTION
## Summary
- Clear neon effect when pointer leaves widget or focus is lost

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0da3e29f883329e863ade00825477