### PR TITLE
Add neon animation effects and event filter

### DIFF
--- a/app/animations.py
+++ b/app/animations.py
@@ -1,0 +1,25 @@
+from PySide6 import QtCore, QtWidgets
+import math
+
+class NeonMotion(QtCore.QObject):
+    """Timer driven animation for cyclic neon offset movement."""
+
+    def __init__(self, effect: QtWidgets.QGraphicsEffect, radius: float = 2.0, speed: float = 1.0):
+        super().__init__(effect)
+        self._effect = effect
+        self._radius = radius
+        self._angle = 0.0
+        self._timer = QtCore.QTimer(self)
+        interval = max(10, int(30 / max(speed, 0.1)))
+        self._timer.timeout.connect(self._update)
+        self._timer.start(interval)
+
+    def _update(self) -> None:
+        self._angle = (self._angle + 5) % 360
+        x = self._radius * math.cos(math.radians(self._angle))
+        y = self._radius * math.sin(math.radians(self._angle))
+        self._effect.setOffset(x, y)
+
+    def stop(self) -> None:
+        self._timer.stop()
+        self._effect.setOffset(0, 0)

--- a/app/effects.py
+++ b/app/effects.py
@@ -1,0 +1,30 @@
+from PySide6 import QtWidgets, QtGui, QtCore
+from animations import NeonMotion
+
+
+def set_neon(widget: QtWidgets.QWidget, color, intensity=255, pulse=False, motion_speed=1.0):
+    """Apply neon drop shadow to *widget* and optionally animate it."""
+    eff = QtWidgets.QGraphicsDropShadowEffect(widget)
+    eff.setOffset(0, 0)
+    eff.setBlurRadius(20)
+    c = QtGui.QColor(color)
+    c.setAlpha(int(intensity))
+    eff.setColor(c)
+    widget.setGraphicsEffect(eff)
+
+    anim = None
+    if pulse:
+        anim = QtCore.QPropertyAnimation(eff, b"blurRadius", widget)
+        anim.setStartValue(20)
+        anim.setEndValue(40)
+        duration = int(1000 / max(motion_speed, 0.1))
+        anim.setDuration(duration)
+        anim.setLoopCount(-1)
+        anim.setEasingCurve(QtCore.QEasingCurve.InOutQuad)
+        anim.start(QtCore.QAbstractAnimation.DeleteWhenStopped)
+
+    motion = None
+    if motion_speed and motion_speed > 0:
+        motion = NeonMotion(eff, speed=motion_speed)
+
+    return eff, anim, motion


### PR DESCRIPTION
## Summary
- add `set_neon` helper and `NeonMotion` timer for animated glow
- start/stop neon animation via rewritten `NeonEventFilter`
- hook NeonEventFilter into table widget and other interactive widgets

## Testing
- `python -m py_compile app/animations.py app/effects.py app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68b13aa396ec8332b3bc198edcd6586a