### PR TITLE
feat: add inner neon mode

### DIFF
--- a/app/effects.py
+++ b/app/effects.py
@@ -2,8 +2,33 @@ from PySide6 import QtWidgets, QtGui, QtCore
 from animations import NeonMotion
 
 
-def set_neon(widget: QtWidgets.QWidget, color, intensity=255, pulse=False, motion_speed=1.0):
-    """Apply neon drop shadow to *widget* and optionally animate it."""
+def set_neon(
+    widget: QtWidgets.QWidget,
+    color,
+    intensity=255,
+    pulse=False,
+    motion_speed=1.0,
+    mode="outer",
+):
+    """
+    Apply neon effect to ``widget`` and optionally animate it.
+
+    ``mode`` can be ``"outer"`` (default) for a drop shadow or ``"inner"`` for a
+    colorize effect based on the widget's ``palette().buttonText()`` color.
+    """
+
+    anim = None
+    motion = None
+
+    if mode == "inner":
+        eff = QtWidgets.QGraphicsColorizeEffect(widget)
+        c = widget.palette().buttonText().color()
+        c.setAlpha(int(intensity))
+        eff.setColor(c)
+        eff.setStrength(1.0)
+        widget.setGraphicsEffect(eff)
+        return eff, None, None
+
     eff = QtWidgets.QGraphicsDropShadowEffect(widget)
     eff.setOffset(0, 0)
     eff.setBlurRadius(20)
@@ -12,7 +37,6 @@ def set_neon(widget: QtWidgets.QWidget, color, intensity=255, pulse=False, motio
     eff.setColor(c)
     widget.setGraphicsEffect(eff)
 
-    anim = None
     if pulse:
         anim = QtCore.QPropertyAnimation(eff, b"blurRadius", widget)
         anim.setStartValue(20)
@@ -23,7 +47,6 @@ def set_neon(widget: QtWidgets.QWidget, color, intensity=255, pulse=False, motio
         anim.setEasingCurve(QtCore.QEasingCurve.InOutQuad)
         anim.start(QtCore.QAbstractAnimation.DeleteWhenStopped)
 
-    motion = None
     if motion_speed and motion_speed > 0:
         motion = NeonMotion(eff, speed=motion_speed)
 

--- a/app/main.py
+++ b/app/main.py
@@ -115,16 +115,23 @@ class NeonEventFilter(QtCore.QObject):
         thickness = CONFIG.get("neon_thickness", 1)
         border = f"border:{thickness}px solid {accent.name()}; border-radius:{radius}px;"
         self._widget.setStyleSheet(self._orig_style + border)
-        eff, anim, motion = set_neon(
-            self._widget,
-            accent,
-            intensity=CONFIG.get("neon_intensity", 255),
-            pulse=CONFIG.get("neon_motion", False),
-            motion_speed=CONFIG.get("animation_speed", 1.0),
-        )
-        self._anim = anim
-        self._motion = motion
-        self._effect = eff
+        if isinstance(self._widget, QtWidgets.QAbstractButton):
+            eff, anim, motion = set_neon(
+                self._widget,
+                accent,
+                intensity=CONFIG.get("neon_intensity", 255),
+                pulse=CONFIG.get("neon_motion", False),
+                motion_speed=CONFIG.get("animation_speed", 1.0),
+                mode="inner",
+            )
+            self._anim = anim
+            self._motion = motion
+            self._effect = eff
+        else:
+            self._widget.setGraphicsEffect(None)
+            self._anim = None
+            self._motion = None
+            self._effect = None
 
     def _stop(self) -> None:
         self._widget.setStyleSheet(self._orig_style)


### PR DESCRIPTION
## Summary
- add optional inner mode for neon effects using QGraphicsColorizeEffect
- switch NeonEventFilter to inner neon on buttons and disable on other widgets

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1534b64888332828c805e7661d770