### PR TITLE
style: customize spinbox arrows

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2024,10 +2024,20 @@ class MainWindow(QtWidgets.QMainWindow):
             app.setPalette(app.style().standardPalette())
         base, workspace = theme_manager.apply_gradient(CONFIG)
         self.topbar.apply_background(workspace)
+        theme = CONFIG.get("theme", "dark")
         self.setStyleSheet(
             "QPushButton,"
             "QToolButton,QSpinBox,QDoubleSpinBox,QTimeEdit,"
             "QComboBox,QLineEdit{" + base + "}"
+            f"""
+            QSpinBox::up-button,QSpinBox::down-button{{
+                border:1px solid transparent;
+                border-radius:8px;
+                width:16px;height:16px;
+            }}
+            QSpinBox::up-arrow{{ image:url(assets/icons/{theme}/chevron-up.svg); }}
+            QSpinBox::down-arrow{{ image:url(assets/icons/{theme}/chevron-down.svg); }}
+            """
         )
         self.table.setStyleSheet(f"QTableWidget {{ background-color: {workspace}; }}")
         for tbl in self.table.cell_tables.values():

--- a/app/resources.py
+++ b/app/resources.py
@@ -29,7 +29,15 @@ def load_icons(theme: str = "dark") -> None:
     if not os.path.isdir(theme_dir):
         return
     ICONS.clear()
-    for name in ["settings", "chevron-left", "chevron-right", "save", "x"]:
+    for name in [
+        "settings",
+        "chevron-left",
+        "chevron-right",
+        "chevron-up",
+        "chevron-down",
+        "save",
+        "x",
+    ]:
         for ext in ("svg", "png"):
             path = os.path.join(theme_dir, f"{name}.{ext}")
             if os.path.exists(path):

--- a/assets/icons/dark/chevron-down.svg
+++ b/assets/icons/dark/chevron-down.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>

--- a/assets/icons/dark/chevron-up.svg
+++ b/assets/icons/dark/chevron-up.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"/></svg>

--- a/assets/icons/light/chevron-down.svg
+++ b/assets/icons/light/chevron-down.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>

--- a/assets/icons/light/chevron-up.svg
+++ b/assets/icons/light/chevron-up.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"/></svg>


### PR DESCRIPTION
## Summary
- add up/down chevron icons for dark and light themes
- extend theme application to style QSpinBox arrows and buttons
- load the new spinbox icons in resources

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1546a99988332aecd08d72b9a56de