### PR TITLE
Stretch table headers and round table border

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -235,8 +235,13 @@ class ReleaseDialog(QtWidgets.QDialog):
 
         self.table = QtWidgets.QTableWidget(0, 4, self)
         self.table.setHorizontalHeaderLabels(["День", "Работа", "Глав", "Время"])
-        self.table.horizontalHeader().setStretchLastSection(True)
+        self.table.horizontalHeader().setSectionResizeMode(QtWidgets.QHeaderView.Stretch)
         self.table.verticalHeader().setVisible(False)
+        self.table.verticalHeader().setSectionResizeMode(QtWidgets.QHeaderView.Stretch)
+        self.table.setStyleSheet(
+            "QTableWidget{border:1px solid #555; border-radius:8px;} "
+            "QTableWidget::item{border:0;}"
+        )
         self.table.setRowCount(self.days_in_month)
 
         app = QtWidgets.QApplication.instance()


### PR DESCRIPTION
## Summary
- Stretch both horizontal and vertical headers to fill available space
- Style table with rounded outer border and no inner item borders
- Confirmed full row generation for months over 17 days

## Testing
- `pytest`
- `QT_QPA_PLATFORM=offscreen python - <<'PY'
import sys
sys.path.append('app')
from PySide6 import QtWidgets
from main import ReleaseDialog
app = QtWidgets.QApplication([])
dlg = ReleaseDialog(2024, 8, [])
print('rows:', dlg.table.rowCount())
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b15a40adec8332921a9ac87d2370fe