### PR TITLE
Remove neon animations and settings

### DIFF
--- a/app/effects.py
+++ b/app/effects.py
@@ -1,24 +1,18 @@
-from PySide6 import QtWidgets, QtGui, QtCore
-from animations import NeonMotion
+from PySide6 import QtWidgets, QtGui
 
 
 def set_neon(
     widget: QtWidgets.QWidget,
     color,
     intensity=255,
-    pulse=False,
-    motion_speed=1.0,
     mode="outer",
 ):
     """
-    Apply neon effect to ``widget`` and optionally animate it.
+    Apply neon effect to ``widget``.
 
     ``mode`` can be ``"outer"`` (default) for a drop shadow or ``"inner"`` for a
     colorize effect based on the widget's ``palette().buttonText()`` color.
     """
-
-    anim = None
-    motion = None
 
     if mode == "inner":
         eff = QtWidgets.QGraphicsColorizeEffect(widget)
@@ -27,7 +21,7 @@ def set_neon(
         eff.setColor(c)
         eff.setStrength(1.0)
         widget.setGraphicsEffect(eff)
-        return eff, None, None
+        return eff
 
     eff = QtWidgets.QGraphicsDropShadowEffect(widget)
     eff.setOffset(0, 0)
@@ -37,17 +31,4 @@ def set_neon(
     eff.setColor(c)
     widget.setGraphicsEffect(eff)
 
-    if pulse:
-        anim = QtCore.QPropertyAnimation(eff, b"blurRadius", widget)
-        anim.setStartValue(20)
-        anim.setEndValue(40)
-        duration = int(1000 / max(motion_speed, 0.1))
-        anim.setDuration(duration)
-        anim.setLoopCount(-1)
-        anim.setEasingCurve(QtCore.QEasingCurve.InOutQuad)
-        anim.start(QtCore.QAbstractAnimation.DeleteWhenStopped)
-
-    if motion_speed and motion_speed > 0:
-        motion = NeonMotion(eff, speed=motion_speed)
-
-    return eff, anim, motion
+    return eff

--- a/data/config.json
+++ b/data/config.json
@@ -8,8 +8,6 @@
   "glass_effect": "Acrylic",
   "glass_opacity": 0.5,
   "glass_blur": 10,
-  "animation_speed": 1.0,
-  "neon_motion": false,
   "header_font": "Exo 2",
   "text_font": "Inter",
   "day_rows": 6,


### PR DESCRIPTION
## Summary
- simplify `set_neon` to apply only a static drop-shadow effect
- drop pulse flag and motion references from `NeonEventFilter`
- remove obsolete Animation settings tab and related config options

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b16ce1a920833283d4945c6abde2ed