### PR TITLE
Add stretch to sidebar layout

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1341,7 +1341,8 @@ class CollapsibleSidebar(QtWidgets.QFrame):
                 self.btn_analytics = b
             elif label == "Топы":
                 self.btn_tops = b
-        # Stretch removed since there is no settings button at the bottom
+        # Push buttons to the top when sidebar is taller than content
+        lay.addStretch(1)
 
         self._collapsed = False
         self.anim = QtCore.QPropertyAnimation(self, b"maximumWidth", self)


### PR DESCRIPTION
## Summary
- Add layout stretch at end of CollapsibleSidebar button creation to push buttons to top when sidebar taller than content.
- Confirm sidebar layout uses consistent contents margins and spacing (8px margins, 6px spacing).

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b172d8bcb0833297d150873b09fd08