### PR TITLE
Refine neon highlighting for calendar cells

### DIFF
--- a/app/effects.py
+++ b/app/effects.py
@@ -1,4 +1,4 @@
-from PySide6 import QtWidgets, QtGui
+from PySide6 import QtWidgets, QtGui, QtCore
 
 
 def set_neon(
@@ -6,6 +6,7 @@ def set_neon(
     color,
     intensity=255,
     mode="outer",
+    pulse=False,
 ):
     """
     Apply neon effect to ``widget``.
@@ -30,5 +31,15 @@ def set_neon(
     c.setAlpha(int(intensity))
     eff.setColor(c)
     widget.setGraphicsEffect(eff)
+
+    if pulse:
+        anim = QtCore.QPropertyAnimation(eff, b"blurRadius", widget)
+        anim.setStartValue(20)
+        anim.setEndValue(40)
+        anim.setDuration(1000)
+        anim.setLoopCount(-1)
+        anim.setEasingCurve(QtCore.QEasingCurve.InOutQuad)
+        anim.start(QtCore.QAbstractAnimation.DeleteWhenStopped)
+        eff._neon_anim = anim
 
     return eff


### PR DESCRIPTION
## Summary
- disable pulse animation in NeonEventFilter and reset highlight effect cleanly
- apply NeonEventFilter to day containers so the whole block glows on hover
- add optional neon flag for inner tables and pulse support in set_neon utility

## Testing
- `python -m py_compile app/effects.py app/main.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b17af4be8883328f801c97b19bb95f