### PR TITLE
Add startup test and syntax pre-check

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -5,6 +5,9 @@ set -e
 
 part=${1:-patch}
 
+# check for syntax errors early
+python -m py_compile app/main.py app/effects.py
+
 # run tests if present
 if [ -d tests ]; then
     python -m pytest

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -1,0 +1,22 @@
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "app"))
+
+from PySide6 import QtWidgets
+
+import resources
+resources.register_fonts = lambda: None
+
+import app.main as main
+
+
+def test_startup():
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    window = main.MainWindow()
+    assert window is not None
+    window.close()
+    app.quit()
+


### PR DESCRIPTION
## Summary
- add a startup test that instantiates `MainWindow` under an offscreen Qt platform
- run `py_compile` and pytest in `release.sh` to catch syntax issues early

## Testing
- `python -m py_compile app/main.py app/effects.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1a61478e8833285dcb324cdf478c5