### PR TITLE
Move font registration after QApplication initialization

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -14,9 +14,6 @@ from resources import register_fonts, load_icons, icon
 import theme_manager
 from effects import NeonEventFilter
 
-# Ensure bundled fonts are loaded before any window is created
-register_fonts()
-
 ASSETS = os.path.join(os.path.dirname(__file__), "..", "assets")
 DATA_DIR = os.path.join(os.path.dirname(__file__), "..", "data")
 CONFIG_PATH = os.path.join(DATA_DIR, "config.json")
@@ -2027,6 +2024,7 @@ class MainWindow(QtWidgets.QMainWindow):
 def main():
     QtCore.QLocale.setDefault(QtCore.QLocale("ru_RU"))
     app = QtWidgets.QApplication(sys.argv)
+    register_fonts()
     load_icons(CONFIG.get("theme", "dark"))
     resolve_font_config()
     theme_manager.set_text_font(CONFIG.get("text_font", "Inter"))

--- a/app/resources.py
+++ b/app/resources.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import logging
 from typing import Dict
 
 from PySide6.QtGui import QFontDatabase, QIcon
@@ -20,7 +21,9 @@ def register_fonts() -> None:
         return
     for fname in os.listdir(FONTS_DIR):
         if fname.lower().endswith((".ttf", ".otf")):
-            QFontDatabase.addApplicationFont(os.path.join(FONTS_DIR, fname))
+            fid = QFontDatabase.addApplicationFont(os.path.join(FONTS_DIR, fname))
+            if fid == -1:
+                logging.getLogger(__name__).error("Failed to load font %s", fname)
 
 
 def load_icons(theme: str = "dark") -> None:


### PR DESCRIPTION
## Summary
- register bundled fonts only after creating the QApplication
- log a warning when a bundled font fails to load

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1bc6fff14833282b6a91a770f5896