### PR TITLE
Simplify plan schedule window title

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1808,7 +1808,7 @@ class TopBar(QtWidgets.QWidget):
 class MainWindow(QtWidgets.QMainWindow):
     def __init__(self):
         super().__init__()
-        self.setWindowTitle("План-график — Excel 1:1 + навигация по месяцам + левый бар")
+        self.setWindowTitle("План-график")
         central = QtWidgets.QWidget(self)
         h = QtWidgets.QHBoxLayout(central); h.setContentsMargins(0,0,0,0); h.setSpacing(0)
 


### PR DESCRIPTION
## Summary
- Shorten plan schedule window title to 'План-график'

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68b1d36538c48332b57a69ca6dfb9149