### PR TITLE
Skip NeonEventFilter for adult checkbox

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -370,7 +370,8 @@ class StatsEntryForm(QtWidgets.QWidget):
             form.addRow(label, w)
             self.widgets[key] = w
             w.setAttribute(QtCore.Qt.WA_Hover, True)
-            w.installEventFilter(NeonEventFilter(w))
+            if key != "adult":  # avoid framing the entire row for checkbox
+                w.installEventFilter(NeonEventFilter(w))
 
     def get_record(self) -> Dict[str, int | float | str | bool]:
         record: Dict[str, int | float | str | bool] = {}


### PR DESCRIPTION
## Summary
- Avoid applying NeonEventFilter to the adult checkbox to prevent highlighting the entire form row.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1df495934833289817c488ace14f0