### PR TITLE
Refine neon styling for border-only effects

### DIFF
--- a/app/effects.py
+++ b/app/effects.py
@@ -58,18 +58,15 @@ def apply_neon_effect(widget: QtWidgets.QWidget, on: bool = True) -> None:
             widget.setProperty("_prev_effect", widget.graphicsEffect())
         if getattr(widget, "_neon_prev_style", None) is None:
             widget._neon_prev_style = widget.styleSheet()
-            match = re.search(r"border-radius:\s*([0-9.]+)px", widget._neon_prev_style)
-            widget._neon_prev_radius = match.group(1) if match else None
         eff = QtWidgets.QGraphicsDropShadowEffect(widget)
         eff.setOffset(0, 0)
         eff.setBlurRadius(20)
         color = widget.palette().color(QtGui.QPalette.Highlight)
         eff.setColor(color)
         widget.setGraphicsEffect(eff)
-        parts = [widget._neon_prev_style, f"border:1px solid {color.name()};"]
-        if widget._neon_prev_radius is not None:
-            parts.append(f"border-radius:{widget._neon_prev_radius}px;")
-        widget.setStyleSheet("".join(parts))
+        widget.setStyleSheet(
+            f"{widget._neon_prev_style}border-color:{color.name()};"
+        )
         widget._neon_effect = eff
     else:
         prev = widget.property("_prev_effect")
@@ -81,7 +78,6 @@ def apply_neon_effect(widget: QtWidgets.QWidget, on: bool = True) -> None:
         prev_style = getattr(widget, "_neon_prev_style", None)
         widget.setStyleSheet(prev_style or "")
         widget._neon_prev_style = None
-        widget._neon_prev_radius = None
         widget._neon_effect = None
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -2030,11 +2030,25 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def apply_style(self, neon: bool):
         accent = QtGui.QColor(CONFIG.get("accent_color", "#39ff14"))
+        workspace = QtGui.QColor(CONFIG.get("workspace_color", "#1e1e21"))
         if CONFIG.get("monochrome", False):
             h, s, v, _ = accent.getHsv()
             s = int(CONFIG.get("mono_saturation", 100))
             accent.setHsv(h, s, v)
+            workspace = theme_manager.apply_monochrome(workspace)
         sidebar = CONFIG.get("sidebar_color", "#1f1f23")
+        border = accent.name() if neon else "#555"
+        style = (
+            f"background:{workspace.name()};" f"border:1px solid {border};" f"border-radius:8px;"
+        )
+        for cls in (
+            QtWidgets.QLineEdit,
+            QtWidgets.QComboBox,
+            QtWidgets.QSpinBox,
+            QtWidgets.QTimeEdit,
+        ):
+            for w in self.findChildren(cls):
+                w.setStyleSheet(style)
         self.topbar.apply_style(neon)
         self.sidebar.apply_style(neon, accent, sidebar)
 


### PR DESCRIPTION
## Summary
- Adjust neon effect to only change widget border color
- Apply workspace background and border-based neon styling to input widgets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b1ec13f3648332b261b18bb9b1ce26