### PR TITLE
Refresh topbar background on workspace color update

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2134,7 +2134,15 @@ class MainWindow(QtWidgets.QMainWindow):
         else:
             app.setPalette(app.style().standardPalette())
         base, workspace = theme_manager.apply_gradient(CONFIG)
-        self.topbar.apply_background(workspace)
+        self.topbar.setStyleSheet(
+            f"background-color:{workspace};" + self.topbar.styleSheet()
+        )
+        self.topbar.lbl_month.setStyleSheet(
+            f"background-color:{workspace};"
+        )
+        self.topbar.spin_year.setStyleSheet(
+            f"background-color:{workspace}; padding:0 6px;"
+        )
         self.table.horizontalHeader().setStyleSheet(
             f"background-color:{workspace};"
         )


### PR DESCRIPTION
### Summary
- ensure top bar background updates when workspace color changes
- recolor month label and year spin box to match workspace

### Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1fdfc89948332807edf816053d698