### PR TITLE
Include assets in PyInstaller build

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -19,7 +19,10 @@ bump2version --current-version "$current_version" "$part"
 
 # build distribution
 if command -v pyinstaller >/dev/null 2>&1; then
-    pyinstaller --onefile app/main.py -n webnovel-planner
+    pyinstaller app/main.py -n webnovel-planner \
+        --add-data "assets/fonts:assets/fonts" \
+        --add-data "assets/icons:assets/icons" \
+        --onefile
 else
     mkdir -p dist
     zip -r dist/app.zip app data assets requirements.txt VERSION


### PR DESCRIPTION
## Summary
- ensure fonts and icons are bundled in the PyInstaller one-file build

## Testing
- `pytest` *(fails: libGL.so.1: cannot open shared object file)*
- `pyinstaller app/main.py -n webnovel-planner --add-data "assets/fonts:assets/fonts" --add-data "assets/icons:assets/icons" --onefile`
- `pyi-archive_viewer dist/webnovel-planner`

------
https://chatgpt.com/codex/tasks/task_e_68b28dcdbb7883329a28e5f96a551a05