### PR TITLE
Use Exo 2 as default application font

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1561,14 +1561,13 @@ class SettingsDialog(QtWidgets.QDialog):
         self.spin_glass_blur.valueChanged.connect(lambda _: self._save_config())
         form_interface.addRow("Размытие стекла", self.spin_glass_blur)
 
-        header_family, text_family = resolve_font_config(self)
         self.font_header = QtWidgets.QFontComboBox(self)
-        self.font_header.setCurrentFont(QtGui.QFont(header_family))
+        self.font_header.setCurrentFont(QtGui.QFont("Exo 2"))
         self.font_header.currentFontChanged.connect(lambda _: self._save_config())
         form_interface.addRow("Шрифт заголовков", self.font_header)
 
         self.font_text = QtWidgets.QFontComboBox(self)
-        self.font_text.setCurrentFont(QtGui.QFont(text_family))
+        self.font_text.setCurrentFont(QtGui.QFont("Exo 2"))
         self.font_text.currentFontChanged.connect(lambda _: self._save_config())
         form_interface.addRow("Шрифт текста", self.font_text)
 
@@ -2200,8 +2199,8 @@ def main():
     # Register bundled fonts now that the application exists
     register_fonts()
     load_icons(CONFIG.get("theme", "dark"))
-    resolve_font_config()
-    theme_manager.set_text_font(CONFIG.get("text_font", "Exo 2"))
+    theme_manager.set_header_font("Exo 2")
+    theme_manager.set_text_font("Exo 2")
     w = MainWindow()
     w.apply_settings()
     w.show()

--- a/app/resources.py
+++ b/app/resources.py
@@ -35,6 +35,9 @@ def register_fonts() -> None:
                         QGuiApplication.setFont(QFont("Arial"))
                         fallback_set = True
 
+    if "Exo 2" not in QFontDatabase().families():
+        logger.error("Font 'Exo 2' not registered")
+
 
 def load_icons(theme: str = "dark") -> None:
     """Load themed icons into the global :data:`ICONS` dictionary."""


### PR DESCRIPTION
## Summary
- verify Exo 2 font is registered when loading fonts
- default header and text fonts to Exo 2 on startup
- initialize Settings dialog font selectors with Exo 2

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b53402376c8332801f7c5fbd6437bb