### PR TITLE
Use static QFontDatabase methods for fonts

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -7,7 +7,6 @@ from datetime import datetime, date
 from typing import Dict, List, Union
 
 from PySide6 import QtWidgets, QtGui, QtCore
-from PySide6.QtGui import QFontDatabase
 from dataclasses import dataclass, field
 
 from widgets import StyledPushButton, StyledToolButton
@@ -100,11 +99,11 @@ RU_MONTHS = ["Январь","Февраль","Март","Апрель","Май",
 def ensure_font_registered(family: str, parent: QtWidgets.QWidget | None = None) -> str:
     """Ensure *family* is available and return its name.
 
-    If *family* is missing in :class:`QFontDatabase`, the user is prompted to
+    If *family* is missing in :class:`QtGui.QFontDatabase`, the user is prompted to
     locate a font file. If the font cannot be loaded, the safe default
     ``"Exo 2"`` is returned.
     """
-    if family in QFontDatabase.families():
+    if family in QtGui.QFontDatabase.families():
         return family
 
     file_path, _ = QtWidgets.QFileDialog.getOpenFileName(
@@ -114,9 +113,9 @@ def ensure_font_registered(family: str, parent: QtWidgets.QWidget | None = None)
         "Font Files (*.ttf *.otf)"
     )
     if file_path:
-        fid = QFontDatabase.addApplicationFont(file_path)
+        fid = QtGui.QFontDatabase.addApplicationFont(file_path)
         if fid != -1:
-            fams = QFontDatabase.applicationFontFamilies(fid)
+            fams = QtGui.QFontDatabase.applicationFontFamilies(fid)
             if fams:
                 return fams[0]
 

--- a/app/resources.py
+++ b/app/resources.py
@@ -6,7 +6,8 @@ import os
 import logging
 from typing import Dict
 
-from PySide6.QtGui import QFontDatabase, QIcon, QFont, QGuiApplication
+from PySide6 import QtGui
+from PySide6.QtGui import QIcon, QFont, QGuiApplication
 
 logger = logging.getLogger(__name__)
 
@@ -28,14 +29,14 @@ def register_fonts() -> None:
         for fname in files:
             if fname.lower().endswith((".ttf", ".otf")):
                 path = os.path.join(root, fname)
-                fid = QFontDatabase.addApplicationFont(path)
+                fid = QtGui.QFontDatabase.addApplicationFont(path)
                 if fid == -1:
                     logger.error("Failed to load font '%s' from '%s'", fname, path)
                     if not fallback_set:
                         QGuiApplication.setFont(QFont("Arial"))
                         fallback_set = True
 
-    if "Exo 2" not in QFontDatabase().families():
+    if "Exo 2" not in QtGui.QFontDatabase.families():
         logger.error("Font 'Exo 2' not registered")
 
 


### PR DESCRIPTION
## Summary
- remove QFontDatabase instantiation and use static QtGui.QFontDatabase methods for font loading in `main.py`
- register fonts via static QtGui.QFontDatabase in `resources.py`

## Testing
- `pytest >/tmp/pytest.log; tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68b5498aedf48332aeeb5c5f44a435c5