### PR TITLE
Move window maximization to startup

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1923,7 +1923,6 @@ class MainWindow(QtWidgets.QMainWindow):
         h.addWidget(right, 1)
 
         self.setCentralWidget(central)
-        self.showMaximized()
 
         # Connect topbar
         self.topbar.prev_clicked.connect(self.prev_month)
@@ -2203,6 +2202,7 @@ def main():
     w = MainWindow()
     w.apply_settings()
     w.show()
+    w.showMaximized()
     sys.exit(app.exec())
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- prevent `MainWindow` from maximizing itself during initialization
- maximize the window after creation in the application entry point

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b554da38d88332a25b275409c2afb3