### PR TITLE
refactor: propagate return codes

### DIFF
--- a/run.py
+++ b/run.py
@@ -13,15 +13,25 @@ VENV_DIR = ROOT / '.venv'
 PYTHON = VENV_DIR / ('Scripts' if os.name == 'nt' else 'bin') / 'python'
 
 
-def main() -> None:
+def main() -> int:
     if not VENV_DIR.exists():
         subprocess.check_call([sys.executable, '-m', 'venv', str(VENV_DIR)])
 
     try:
-        subprocess.check_call([str(PYTHON), '-m', 'pip', 'install', '--upgrade', '-r', str(ROOT / 'requirements.txt')])
+        subprocess.check_call(
+            [
+                str(PYTHON),
+                '-m',
+                'pip',
+                'install',
+                '--upgrade',
+                '-r',
+                str(ROOT / 'requirements.txt'),
+            ]
+        )
     except subprocess.CalledProcessError as exc:
         print(f'Не удалось установить зависимости: {exc}', file=sys.stderr)
-        sys.exit(exc.returncode)
+        return exc.returncode
 
     try:
         subprocess.check_call([str(PYTHON), str(ROOT / 'app' / 'main.py')])
@@ -30,8 +40,10 @@ def main() -> None:
             f"Application failed with exit code {exc.returncode}",
             file=sys.stderr,
         )
-        sys.exit(exc.returncode)
+        return exc.returncode
+
+    return 0
 
 
 if __name__ == '__main__':
-    main()
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- always install upgraded dependencies regardless of virtualenv existence
- provide clearer error handling for dependency install and app launch
- propagate subprocess return codes for CI clarity

## Testing
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68b5717008848332b29462a4038a5cf0