### PR TITLE
Improve run script error reporting

### DIFF
--- a/run.py
+++ b/run.py
@@ -33,14 +33,20 @@ def main() -> int:
         print(f'Не удалось установить зависимости: {exc}', file=sys.stderr)
         return exc.returncode
 
-    try:
-        subprocess.check_call([str(PYTHON), str(ROOT / 'app' / 'main.py')])
-    except subprocess.CalledProcessError as exc:
+    result = subprocess.run(
+        [str(PYTHON), '-X', 'faulthandler', str(ROOT / 'app' / 'main.py')],
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        if result.stderr:
+            print(result.stderr, file=sys.stderr, end="")
         print(
-            f"Application failed with exit code {exc.returncode}",
+            f"Application failed with exit code {result.returncode}",
             file=sys.stderr,
         )
-        return exc.returncode
+        return result.returncode
 
     return 0
 


### PR DESCRIPTION
## Summary
- capture `app/main.py` stderr on failure
- run app with `-X faulthandler` to show crash traces

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5ac3fa3b88332a9235a6fa5ec1aa6