### PR TITLE
Wrap app startup in exception handler

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2231,5 +2231,12 @@ if __name__ == "__main__":
     QtCore.QLocale.setDefault(QtCore.QLocale("ru_RU"))
     app = QtWidgets.QApplication(sys.argv)
     register_fonts()
-    main()
-    sys.exit(app.exec())
+    try:
+        main()
+        sys.exit(app.exec())
+    except Exception as exc:
+        logging.exception("Unhandled exception in application")
+        QtWidgets.QMessageBox.critical(
+            None, "Ошибка", f"{type(exc).__name__}: {exc}"
+        )
+        sys.exit(1)


### PR DESCRIPTION
## Summary
- handle uncaught exceptions on startup
- display critical message box and exit with non-zero status

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5b313896c8332a45980fe44ede7c8