### PR TITLE
docs: add changelog and contributor guidelines

### DIFF
--- a/CHANGELOG.md2
+++ b/CHANGELOG.md2
@@ -1,0 +1,6 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. Each merge to the main branch must add a new section with the updated version number and a concise list of changes.
+
+## [1.2.0] - 2025-09-01
+- Initial changelog entry.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,8 @@
+# Contributing
+
+## Changelog and versioning
+- Each merge to the main branch must append a new section to `CHANGELOG.md2` with the new version and a summary of changes.
+- After editing `CHANGELOG.md2`, run `bump2version` to update `VERSION` and `data/config.json` before committing.
+
+## Release
+Use `release.sh` to create a release. The script will fail if `CHANGELOG.md2` was not updated and will automatically bump the version using `bump2version`.

--- a/release.sh
+++ b/release.sh
@@ -13,7 +13,13 @@ if [ -d tests ]; then
     python -m pytest
 fi
 
-# bump version in VERSION and config.json
+# ensure changelog is updated before bumping version
+if git diff --quiet HEAD -- CHANGELOG.md2; then
+    echo "CHANGELOG.md2 must be updated before releasing."
+    exit 1
+fi
+
+# bump version in VERSION and data/config.json
 current_version=$(cat VERSION)
 bump2version --current-version "$current_version" "$part"
 


### PR DESCRIPTION
## Summary
- add root `CHANGELOG.md2` starting at v1.2.0
- document changelog and bump2version rules in `CONTRIBUTING.md`
- fail release if changelog wasn't updated before bumping the version

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5ba26eed08332bc09bddd156671d9