### PR TITLE
Retain window scope during application run

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2232,8 +2232,9 @@ if __name__ == "__main__":
     app = QtWidgets.QApplication(sys.argv)
     register_fonts()
     try:
-        main()
-        sys.exit(app.exec())
+        window = main()
+        exit_code = app.exec()
+        sys.exit(exit_code)
     except Exception as exc:
         logging.exception("Unhandled exception in application")
         QtWidgets.QMessageBox.critical(


### PR DESCRIPTION
## Summary
- Keep main window alive by assigning `window = main()`
- Capture `app.exec()` exit code to ensure `window` stays in scope until event loop finishes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5c5910be48332afc606f1389f4169