### PR TITLE
Set neon effect text colour from palette

### DIFF
--- a/app/effects.py
+++ b/app/effects.py
@@ -77,6 +77,7 @@ def apply_neon_effect(widget: QtWidgets.QWidget, on: bool = True) -> None:
             widget._neon_prev_style = widget.styleSheet()
         prev_style = widget._neon_prev_style or ""
         color = widget.palette().color(QtGui.QPalette.Highlight)
+        text_color = widget.palette().buttonText().color()
         eff = QtWidgets.QGraphicsDropShadowEffect(widget)
         eff.setOffset(0, 0)
         eff.setBlurRadius(20)
@@ -85,7 +86,10 @@ def apply_neon_effect(widget: QtWidgets.QWidget, on: bool = True) -> None:
             widget.setGraphicsEffect(eff)
         except RuntimeError:
             return
-        widget.setStyleSheet(prev_style + f" border-color:{color.name()};")
+        widget.setStyleSheet(
+            prev_style
+            + f" color:{text_color.name()}; border-color:{color.name()};"
+        )
         widget._neon_effect = eff
     else:
         prev = getattr(widget, "_neon_prev_effect", None)


### PR DESCRIPTION
## Summary
- Ensure ButtonStyleMixin applies default text colour
- Sync neon text colour with palette when highlighting

## Testing
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68b6152d20888332a2d1c4ab7c30ff7b