### PR TITLE
Refine neon interaction handling

### DIFF
--- a/app/effects.py
+++ b/app/effects.py
@@ -141,7 +141,11 @@ class NeonEventFilter(QtCore.QObject):
     def eventFilter(self, obj, event):  # noqa: D401 - Qt event filter signature
         if not neon_enabled():
             return False
-        if event.type() in (QtCore.QEvent.HoverEnter, QtCore.QEvent.FocusIn):
+        if event.type() in (
+            QtCore.QEvent.HoverEnter,
+            QtCore.QEvent.FocusIn,
+            QtCore.QEvent.MouseButtonDblClick,
+        ):
             self._start()
         elif event.type() in (
             QtCore.QEvent.HoverLeave,


### PR DESCRIPTION
## Summary
- Trigger neon highlighting on double-clicks via `NeonEventFilter`
- Scope neon filter to individual calendar cells instead of entire table
- Add `apply_neon_to_inputs` helper to attach filters to editable settings widgets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b6bb4a54808332a556878db9a6caa4