### PR TITLE
Update calendar fonts immediately after header font change

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1343,6 +1343,15 @@ class ExcelCalendarTable(QtWidgets.QTableWidget):
         self._update_row_heights()
         return True
 
+    def apply_fonts(self):
+        """Apply current header font to calendar elements."""
+        header_font = QtGui.QFont(CONFIG.get("header_font", "Exo 2"))
+        self.horizontalHeader().setFont(header_font)
+        for tbl in self.cell_tables.values():
+            tbl.horizontalHeader().setFont(header_font)
+        for lbl in self.day_labels.values():
+            lbl.setFont(header_font)
+
     # ---------- Navigation ----------
     def go_prev_month(self):
         self.save_current_month()
@@ -1644,7 +1653,7 @@ class SettingsDialog(QtWidgets.QDialog):
 
         self.font_header = QtWidgets.QFontComboBox(self)
         self.font_header.setCurrentFont(QtGui.QFont("Exo 2"))
-        self.font_header.currentFontChanged.connect(lambda _: self._save_config())
+        self.font_header.currentFontChanged.connect(lambda _: self.apply_fonts())
         form_interface.addRow("Шрифт заголовков", self.font_header)
 
         self.font_text = QtWidgets.QFontComboBox(self)
@@ -1811,6 +1820,16 @@ class SettingsDialog(QtWidgets.QDialog):
             theme_manager.apply_glass_effect(self.main_window)
         theme_manager.apply_glass_effect(self)
         self.settings_changed.emit()
+
+    def apply_fonts(self):
+        """Save and apply new header font immediately."""
+        self._save_config()
+        theme_manager.set_header_font(self.font_header.currentFont().family())
+        parent = self.parent()
+        if parent and hasattr(parent, "table"):
+            parent.table.apply_fonts()
+            if hasattr(parent, "topbar"):
+                parent.topbar.update_labels()
 
     def accept(self):
         self._save_config()

--- a/tests/test_calendar_font_update.py
+++ b/tests/test_calendar_font_update.py
@@ -1,0 +1,36 @@
+import os
+import sys
+import json
+from pathlib import Path
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "app"))
+
+from PySide6 import QtWidgets, QtGui
+
+import resources
+
+resources.register_fonts = lambda: None
+
+import app.main as main
+
+
+def test_day_label_font_updates_immediately(tmp_path):
+    main.CONFIG["header_font"] = "Arial"
+    main.CONFIG_PATH = str(tmp_path / "config.json")
+    with open(main.CONFIG_PATH, "w", encoding="utf-8") as f:
+        json.dump(main.CONFIG, f)
+
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    window = main.MainWindow()
+    dlg = main.SettingsDialog(window)
+
+    dlg.font_header.setCurrentFont(QtGui.QFont("DejaVu Serif"))
+    lbl = next(iter(window.table.day_labels.values()))
+
+    assert lbl.font().family() == "DejaVu Serif"
+
+    dlg.close()
+    window.close()
+    app.quit()
+


### PR DESCRIPTION
## Summary
- Add `ExcelCalendarTable.apply_fonts` to refresh day cell and header fonts when the header font changes
- Extend `SettingsDialog` to save and apply new header fonts immediately without month navigation
- Cover font refresh with a new unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6ce306b44833289976aff8b7773a3