### PR TITLE
Add configurable sidebar font

### DIFF
--- a/app/theme_manager.py
+++ b/app/theme_manager.py
@@ -11,7 +11,17 @@ def set_text_font(name: str = "Exo 2") -> None:
         return
     font = QtGui.QFont(name)
     app.setFont(font)
+    def _in_sidebar(w: QtWidgets.QWidget) -> bool:
+        parent = w
+        while parent is not None:
+            if parent.objectName() == "Sidebar":
+                return True
+            parent = parent.parent()
+        return False
+
     for widget in app.allWidgets():
+        if _in_sidebar(widget):
+            continue
         widget.setFont(font)
 
 

--- a/tests/test_sidebar_font.py
+++ b/tests/test_sidebar_font.py
@@ -1,0 +1,39 @@
+import os
+import sys
+import json
+from pathlib import Path
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "app"))
+
+from PySide6 import QtWidgets, QtGui
+
+import resources
+resources.register_fonts = lambda: None
+
+import app.main as main
+
+
+def test_sidebar_font_persists(tmp_path):
+    main.CONFIG["sidebar_font"] = "Arial"
+    main.CONFIG_PATH = str(tmp_path / "config.json")
+    with open(main.CONFIG_PATH, "w", encoding="utf-8") as f:
+        json.dump(main.CONFIG, f)
+
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    window = main.MainWindow()
+    window.apply_settings()
+
+    first_btn = window.sidebar.buttons[0]
+    assert first_btn.font().family() == "Arial"
+
+    dlg = main.SettingsDialog(window)
+    dlg.font_sidebar.setCurrentFont(QtGui.QFont("DejaVu Serif"))
+    assert first_btn.font().family() == "DejaVu Serif"
+
+    window.apply_settings()
+    assert first_btn.font().family() == "DejaVu Serif"
+
+    dlg.close()
+    window.close()
+    app.quit()


### PR DESCRIPTION
## Summary
- store sidebar font family in configuration and settings dialog
- apply sidebar font to CollapsibleSidebar widgets and prevent global overrides
- exclude sidebar from global text font updates and add regression test

## Testing
- `pytest tests/test_sidebar_font.py -q` *(fails: process hung)*

------
https://chatgpt.com/codex/tasks/task_e_68b6d36157288332b420ba5e8ac2d0df