### PR TITLE
Ensure top bar follows workspace color

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2277,7 +2277,9 @@ class MainWindow(QtWidgets.QMainWindow):
         self.apply_theme()
         theme_manager.apply_glass_effect(self)
         update_neon_filters(self)
-        self.topbar.update_background(sidebar_color)
+        # Ensure the top bar follows the workspace color rather than the sidebar
+        # color so that changing the workspace theme updates the bar
+        self.topbar.update_background(workspace)
         self.topbar.update_labels()
 
 


### PR DESCRIPTION
## Summary
- Use workspace color when updating the top bar background so the bar tracks workspace theme changes

## Testing
- `pytest tests/test_calendar_theme.py::test_calendar_status_row_colors_follow_workspace -q`


------
https://chatgpt.com/codex/tasks/task_e_68b81d859a7883328d57e2a4e149f183