### PR TITLE
Remove gradient from input widgets style

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2334,7 +2334,10 @@ class MainWindow(QtWidgets.QMainWindow):
             app.setPalette(pal)
         else:
             app.setPalette(app.style().standardPalette())
-        base, workspace = theme_manager.apply_gradient(CONFIG)
+        # Exclude gradient for input widgets to keep a flat background
+        grad_cfg = CONFIG.copy()
+        grad_cfg.pop("gradient_colors", None)
+        base, workspace = theme_manager.apply_gradient(grad_cfg)
         self.topbar.setStyleSheet(
             f"background-color:{workspace};" + self.topbar.styleSheet()
         )

--- a/app/theme_manager.py
+++ b/app/theme_manager.py
@@ -51,21 +51,22 @@ def apply_gradient(config: Dict) -> Tuple[str, str]:
         workspace = apply_monochrome(QtGui.QColor(workspace)).name()
         if grad and len(grad) == 2:
             grad = [apply_monochrome(QtGui.QColor(c)).name() for c in grad]
-    if grad and len(grad) == 2:
+
+    base = (
+        f"border:1px solid #555; border-radius:8px; "
+        f"background-color:{workspace};"
+    )
+
+    if grad and len(grad) == 2 and grad[0] != grad[1]:
         angle = config.get("gradient_angle", 0)
         rad = math.radians(angle)
         x2 = 0.5 + 0.5 * math.cos(rad)
         y2 = 0.5 + 0.5 * math.sin(rad)
-        base = (
-            f"border:1px solid #555; border-radius:8px; "
-            f"background:qlineargradient(x1:0,y1:0,x2:{x2:.2f},y2:{y2:.2f}, "
+        base += (
+            f" background:qlineargradient(x1:0,y1:0,x2:{x2:.2f},y2:{y2:.2f}, "
             f"stop:0 {grad[0]}, stop:1 {grad[1]});"
         )
-    else:
-        base = (
-            f"border:1px solid #555; border-radius:8px; "
-            f"background-color:{workspace};"
-        )
+
     return base, workspace
 
 


### PR DESCRIPTION
## Summary
- ensure theme_manager builds base styles with a default background color and only append gradients when needed
- apply app styles using a gradient-free copy of the config for input widgets

## Testing
- `python -m pip install -r requirements.txt`
- `python - <<'PY'
import sys
sys.path.insert(0,'app')
import main, theme_manager
cfg = main.CONFIG.copy(); cfg.pop('gradient_colors', None)
base, workspace = theme_manager.apply_gradient(cfg)
print(base)
assert 'qlineargradient' not in base
print('qlineargradient not in base')
PY
`

------
https://chatgpt.com/codex/tasks/task_e_68b820c46da08332aa60fbe7810e2ac0