### PR TITLE
feat: customize combobox arrow icon

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2370,6 +2370,15 @@ class MainWindow(QtWidgets.QMainWindow):
             }}
             QSpinBox::up-arrow,QDoubleSpinBox::up-arrow{{ image:url(assets/icons/{theme}/chevron-up.svg); }}
             QSpinBox::down-arrow,QDoubleSpinBox::down-arrow{{ image:url(assets/icons/{theme}/chevron-down.svg); }}
+            QComboBox::down-arrow{{
+                image:url(assets/icons/{theme}/chevron-down.svg);
+                width:10px;height:10px;
+            }}
+            QComboBox::drop-down{{
+                subcontrol-origin:padding;
+                subcontrol-position:right center;
+                width:16px;
+            }}
             """
         )
         self.table.apply_theme()


### PR DESCRIPTION
## Summary
- show themed chevron on QComboBox arrows

## Testing
- `pytest` *(fails: hangs after partial run, missing display?)*

------
https://chatgpt.com/codex/tasks/task_e_68b8344d46c08332b7f2fcd9df993817