### PR TITLE
Avoid QLabel border in neon effect

### DIFF
--- a/app/effects.py
+++ b/app/effects.py
@@ -86,10 +86,15 @@ def apply_neon_effect(widget: QtWidgets.QWidget, on: bool = True) -> None:
             widget.setGraphicsEffect(eff)
         except RuntimeError:
             return
-        widget.setStyleSheet(
-            prev_style
-            + f" color:{text_color.name()}; border-color:{color.name()};"
-        )
+        if isinstance(widget, QtWidgets.QLabel):
+            widget.setStyleSheet(
+                prev_style + f" color:{text_color.name()}; border-width:0;"
+            )
+        else:
+            widget.setStyleSheet(
+                prev_style
+                + f" color:{text_color.name()}; border-color:{color.name()};"
+            )
         widget._neon_effect = eff
     else:
         prev = getattr(widget, "_neon_prev_effect", None)
@@ -106,7 +111,10 @@ def apply_neon_effect(widget: QtWidgets.QWidget, on: bool = True) -> None:
         except RuntimeError:
             pass
         prev_style = getattr(widget, "_neon_prev_style", None)
-        widget.setStyleSheet(prev_style or "")
+        style = prev_style or ""
+        if isinstance(widget, QtWidgets.QLabel):
+            style += " border:none;"
+        widget.setStyleSheet(style)
         widget._neon_prev_style = None
         widget._neon_effect = None
 

--- a/tests/test_neon_effect.py
+++ b/tests/test_neon_effect.py
@@ -1,0 +1,24 @@
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "app"))
+
+from PySide6 import QtWidgets
+
+import resources
+resources.register_fonts = lambda: None
+
+import app.main as main
+from app.effects import apply_neon_effect
+
+def test_lbl_month_border_reset_after_neon_effect():
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    window = main.MainWindow()
+    label = window.topbar.lbl_month
+    apply_neon_effect(label, True)
+    apply_neon_effect(label, False)
+    assert "border:none" in label.styleSheet().replace(" ", "")
+    window.close()
+    app.quit()


### PR DESCRIPTION
## Summary
- Skip border color when applying neon effect to `QLabel` and always remove its border when the effect ends
- Add regression test ensuring `TopBar.lbl_month` restores a borderless style after neon highlight

## Testing
- `pytest tests/test_neon_effect.py::test_lbl_month_border_reset_after_neon_effect -q`
- `pytest -q` *(fails: process hung, unable to capture full suite results)*

------
https://chatgpt.com/codex/tasks/task_e_68bbe5240a6c8332b4aa08a01fbb19c8