### PR TITLE
Enable hover neon effect for day labels

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1324,6 +1324,7 @@ class ExcelCalendarTable(QtWidgets.QTableWidget):
                 lbl = QtWidgets.QLabel(str(day.day), container)
                 lbl.setFont(QtGui.QFont(CONFIG["header_font"]))
                 lbl.setAlignment(QtCore.Qt.AlignCenter)
+                lbl.setAttribute(QtCore.Qt.WA_Hover, True)
                 # keep reference for later font updates
                 self.day_labels[(r, c)] = lbl
                 lay.addWidget(lbl, alignment=QtCore.Qt.AlignHCenter)
@@ -1334,9 +1335,11 @@ class ExcelCalendarTable(QtWidgets.QTableWidget):
                     container.setAttribute(QtCore.Qt.WA_Hover, True)
                     filt = NeonEventFilter(container)
                     container.installEventFilter(filt)
+                    lbl.installEventFilter(filt)
                     inner.installEventFilter(filt)
                     inner.viewport().installEventFilter(filt)
                     container._neon_filter = filt
+                    lbl._neon_filter = filt
                 self.setCellWidget(r, c, container)
                 self.date_map[(r, c)] = day
                 self.cell_tables[(r, c)] = inner


### PR DESCRIPTION
## Summary
- apply `WA_Hover` attribute to calendar day labels and attach `NeonEventFilter`

## Testing
- `pytest` *(fails: hangs during `tests/test_sidebar_font.py`)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7b2e6e488332ac02d9d87ee54a51