### PR TITLE
Clear sidebar highlight when dialogs close

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2170,10 +2170,12 @@ class MainWindow(QtWidgets.QMainWindow):
     def open_input_dialog(self):
         dlg = StatsDialog(self.table.year, self.table.month, self)
         dlg.exec()
+        self.sidebar.activate_button(None)
 
     def open_analytics_dialog(self):
         dlg = AnalyticsDialog(self.table.year, self)
         dlg.exec()
+        self.sidebar.activate_button(None)
 
     def _collect_work_names(self) -> List[str]:
         names = set()
@@ -2195,10 +2197,12 @@ class MainWindow(QtWidgets.QMainWindow):
         works = self._collect_work_names()
         dlg = ReleaseDialog(self.table.year, self.table.month, works, self)
         dlg.exec()
+        self.sidebar.activate_button(None)
 
     def open_top_dialog(self):
         dlg = TopDialog(self.table.year, self)
         dlg.exec()
+        self.sidebar.activate_button(None)
 
     def open_settings_dialog(self):
         dlg = SettingsDialog(self)


### PR DESCRIPTION
## Summary
- Call `sidebar.activate_button(None)` after Stats, Release, Analytics, and Top dialogs close to clear sidebar highlight

## Testing
- `pytest -q` *(fails: hangs after starting tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bc800faf948332b1f40437d739114e