### PR TITLE
Remove custom SpinButton and rely on QSpinBox arrows

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -11,7 +11,7 @@ from PySide6 import QtWidgets, QtGui, QtCore
 import shiboken6
 from dataclasses import dataclass, field
 
-from widgets import StyledPushButton, StyledToolButton, SpinButton
+from widgets import StyledPushButton, StyledToolButton
 from resources import register_fonts, load_icons, icon
 import theme_manager
 from effects import NeonEventFilter, neon_enabled, update_neon_filters, apply_neon_effect
@@ -840,11 +840,7 @@ class TopDialog(QtWidgets.QDialog):
         self.spin_year.setRange(2000, 2100)
         self.spin_year.setValue(year)
         self.spin_year.setStyleSheet("padding:0 6px;")
-        self.spin_year.setFixedWidth(self.spin_year.sizeHint().width() + 20)
-        self.spin_year.setButtonSymbols(QtWidgets.QAbstractSpinBox.NoButtons)
         self.spin_year.setAttribute(QtCore.Qt.WA_Hover, True)
-        self.btn_year_dec = SpinButton(self.spin_year, -1, self)
-        self.btn_year_inc = SpinButton(self.spin_year, 1, self)
         if neon_enabled():
             filt = NeonEventFilter(self.spin_year)
             self.spin_year.installEventFilter(filt)
@@ -875,9 +871,7 @@ class TopDialog(QtWidgets.QDialog):
 
         row = QtWidgets.QHBoxLayout()
         row.setContentsMargins(0, 0, 0, 0)
-        row.addWidget(self.btn_year_dec)
         row.addWidget(self.spin_year)
-        row.addWidget(self.btn_year_inc)
         row.addWidget(self.combo_mode)
         row.addWidget(self.combo_period)
         row.addWidget(self.btn_calc)

--- a/app/widgets.py
+++ b/app/widgets.py
@@ -67,24 +67,3 @@ class StyledToolButton(ButtonStyleMixin, QtWidgets.QToolButton):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.apply_base_style()
-
-
-class SpinButton(StyledToolButton):
-    """Small tool button used to step a spin box."""
-
-    def __init__(self, spinbox: QtWidgets.QAbstractSpinBox, step: int, parent=None):
-        super().__init__(parent)
-        self._spinbox = spinbox
-        self._step = 1 if step >= 0 else -1
-        icon_name = "chevron-up" if self._step > 0 else "chevron-down"
-        self.setIcon(icon(icon_name))
-        self.setIconSize(QtCore.QSize(12, 12))
-        self.setFixedSize(20, 20)
-        self.setAutoRepeat(True)
-        self.clicked.connect(self._on_clicked)
-
-    def _on_clicked(self) -> None:
-        if self._step > 0:
-            self._spinbox.stepUp()
-        else:
-            self._spinbox.stepDown()


### PR DESCRIPTION
## Summary
- remove `SpinButton` widget and its import
- use `QSpinBox` built-in buttons in `TopDialog`

## Testing
- `QT_QPA_PLATFORM=offscreen pytest tests/test_startup.py -q`
- `QT_QPA_PLATFORM=offscreen pytest -q` *(fails: command hung without finishing)*

------
https://chatgpt.com/codex/tasks/task_e_68bc8966388c8332aa6a653649e6ccaf