### PR TITLE
Refresh accent color styling for sidebar

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2274,6 +2274,11 @@ class MainWindow(QtWidgets.QMainWindow):
             h, s, v, _ = accent.getHsv()
             s = int(CONFIG.get("mono_saturation", 100))
             accent.setHsv(h, s, v)
+        # ensure widgets use the latest accent color for borders and neon effects
+        app = QtWidgets.QApplication.instance()
+        pal = app.palette()
+        pal.setColor(QtGui.QPalette.Highlight, accent)
+        app.setPalette(pal)
         sidebar_color = CONFIG.get("sidebar_color", "#1f1f23")
         self.topbar.apply_style(CONFIG.get("neon", False))
         self.sidebar.apply_style(CONFIG.get("neon", False), accent, sidebar_color)
@@ -2312,6 +2317,10 @@ class MainWindow(QtWidgets.QMainWindow):
         ):
             for w in self.findChildren(cls):
                 w.setStyleSheet(style)
+        app = QtWidgets.QApplication.instance()
+        pal = app.palette()
+        pal.setColor(QtGui.QPalette.Highlight, accent)
+        app.setPalette(pal)
         self.topbar.apply_style(neon)
         self.sidebar.apply_style(neon, accent, sidebar)
         update_neon_filters(self)

--- a/tests/test_accent_color_update.py
+++ b/tests/test_accent_color_update.py
@@ -1,0 +1,43 @@
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+# ensure app package importable
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "app"))
+
+from PySide6 import QtWidgets, QtGui
+
+import resources
+resources.register_fonts = lambda: None
+
+import app.main as main
+
+
+def test_sidebar_updates_on_accent_change(monkeypatch):
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    window = main.MainWindow()
+    window.apply_settings()
+
+    calls = []
+
+    def fake_apply_style(self, neon, accent, sidebar_color):
+        # record the accent and palette highlight at call time
+        highlight = QtWidgets.QApplication.instance().palette().color(
+            QtGui.QPalette.Highlight
+        ).name()
+        calls.append((accent.name(), highlight))
+
+    monkeypatch.setattr(window.sidebar, "apply_style", fake_apply_style)
+
+    new_color = "#ff0000"
+    main.CONFIG["accent_color"] = new_color
+    window.apply_palette()
+
+    assert calls, "apply_style was not called"
+    accent_name, highlight_name = calls[-1]
+    assert accent_name == new_color.lower()
+    assert highlight_name == new_color.lower()
+
+    window.close()
+    app.quit()


### PR DESCRIPTION
## Summary
- refresh application highlight color before re-applying sidebar and topbar styles
- ensure runtime styling uses updated accent color
- add regression test for sidebar restyle on accent changes

## Testing
- `pytest tests/test_accent_color_update.py -q` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bd1096a7048332a3c101998b19b3ba