### PR TITLE
Handle repeated 'Other' accent color selection

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1628,7 +1628,8 @@ class SettingsDialog(QtWidgets.QDialog):
             self.combo_accent.setItemIcon(other_index, QtGui.QIcon(pix))
         self._accent_index = idx
         # connect after setting initial index to avoid unwanted color dialog
-        self.combo_accent.currentIndexChanged.connect(self._on_accent_changed)
+        # use activated so selecting "Другой" again reopens the color picker
+        self.combo_accent.activated.connect(self._on_accent_changed)
         form_interface.addRow("Цвет подсветки", self.combo_accent)
 
         self._workspace_color = QtGui.QColor(CONFIG.get("workspace_color", "#1e1e21"))

--- a/tests/test_accent_other_dialog.py
+++ b/tests/test_accent_other_dialog.py
@@ -1,0 +1,41 @@
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "app"))
+
+from PySide6 import QtWidgets, QtGui
+
+import resources
+
+resources.register_fonts = lambda: None
+
+import app.main as main
+
+
+def test_other_selection_always_opens_dialog(monkeypatch):
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    dlg = main.SettingsDialog()
+
+    calls = []
+
+    def fake_get_color(initial, *args, **kwargs):
+        calls.append(True)
+        # return some valid color
+        return QtGui.QColor("#010203")
+
+    monkeypatch.setattr(QtWidgets.QColorDialog, "getColor", fake_get_color)
+
+    other_index = dlg.combo_accent.count() - 1
+
+    # simulate selecting "Other" twice without changing index
+    dlg.combo_accent.setCurrentIndex(other_index)
+    dlg.combo_accent.activated.emit(other_index)
+    dlg.combo_accent.activated.emit(other_index)
+
+    assert len(calls) == 2
+
+    dlg.close()
+    app.quit()
+


### PR DESCRIPTION
## Summary
- use `combo_accent.activated` so selecting "Другой" repeatedly always opens the color picker
- add regression test ensuring repeated "Other" selection triggers the dialog

## Testing
- `pytest -q` *(fails: command hangs in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68bd12d291108332ae5caeafd7faebaa