### PR TITLE
Ensure header font persists across month changes

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1337,7 +1337,13 @@ class ExcelCalendarTable(QtWidgets.QTableWidget):
                 lay.setContentsMargins(0, 0, 0, 0)
                 lay.setSpacing(2)
                 lbl = QtWidgets.QLabel(str(day.day), container)
-                lbl.setFont(QtGui.QFont(CONFIG["header_font"]))
+                lbl.setFont(
+                    QtGui.QFont(
+                        CONFIG.get(
+                            "header_font", CONFIG.get("font_family", "Exo 2")
+                        )
+                    )
+                )
                 lbl.setAlignment(QtCore.Qt.AlignCenter)
                 lbl.setAttribute(QtCore.Qt.WA_Hover, True)
                 # keep reference for later font updates
@@ -1376,11 +1382,14 @@ class ExcelCalendarTable(QtWidgets.QTableWidget):
                             item = QtWidgets.QTableWidgetItem(str(row.get(key, "")))
                             inner.setItem(rr, cc, item)
         self._update_row_heights()
+        self.apply_fonts()
         return True
 
     def apply_fonts(self):
         """Apply current header font to calendar elements."""
-        header_font = QtGui.QFont(CONFIG.get("header_font", "Exo 2"))
+        header_font = QtGui.QFont(
+            CONFIG.get("header_font", CONFIG.get("font_family", "Exo 2"))
+        )
         self.horizontalHeader().setFont(header_font)
         for tbl in self.cell_tables.values():
             tbl.horizontalHeader().setFont(header_font)
@@ -2021,7 +2030,9 @@ class TopBar(QtWidgets.QWidget):
         self.apply_fonts()
 
     def apply_fonts(self):
-        font = QtGui.QFont(CONFIG.get("header_font", "Exo 2"))
+        font = QtGui.QFont(
+            CONFIG.get("header_font", CONFIG.get("font_family", "Exo 2"))
+        )
         font.setBold(True)
         self.lbl_month.setFont(font)
 

--- a/tests/test_calendar_font_update.py
+++ b/tests/test_calendar_font_update.py
@@ -34,3 +34,25 @@ def test_day_label_font_updates_immediately(tmp_path):
     window.close()
     app.quit()
 
+
+def test_header_font_persists_after_month_change(tmp_path):
+    main.CONFIG["header_font"] = "Arial"
+    main.CONFIG_PATH = str(tmp_path / "config.json")
+    with open(main.CONFIG_PATH, "w", encoding="utf-8") as f:
+        json.dump(main.CONFIG, f)
+
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    window = main.MainWindow()
+    dlg = main.SettingsDialog(window)
+    dlg.font_header.setCurrentFont(QtGui.QFont("DejaVu Serif"))
+    dlg.close()
+
+    window.next_month()
+    lbl = next(iter(window.table.day_labels.values()))
+
+    assert lbl.font().family() == "DejaVu Serif"
+    assert window.topbar.lbl_month.font().family() == "DejaVu Serif"
+
+    window.close()
+    app.quit()
+


### PR DESCRIPTION
## Summary
- Reapply `CONFIG['header_font']` to top bar and calendar widgets when months change
- Default header font to user-selected base font to avoid unexpected resets
- Test that header fonts persist after changing months

## Testing
- `pytest tests/test_theme_change.py -q`
- `pytest tests/test_calendar_font_update.py -q`
- Attempted `pytest tests/test_accent_color_update.py -q` *(hung)*

------
https://chatgpt.com/codex/tasks/task_e_68bd209d56288332b99135a45a5303d5