### PR TITLE
Preserve calendar day header fonts after text font change

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1900,6 +1900,11 @@ class SettingsDialog(QtWidgets.QDialog):
     def accept(self):
         self._save_config()
         theme_manager.set_text_font(self.font_text.currentFont().family())
+        parent = self.parent()
+        if parent and hasattr(parent, "table"):
+            parent.table.apply_fonts()
+            if hasattr(parent, "topbar"):
+                parent.topbar.update_labels()
         theme_manager.set_header_font(self.font_header.currentFont().family())
         super().accept()
 


### PR DESCRIPTION
## Summary
- Reapply calendar table fonts after updating application text font so day labels keep the configured header font

## Testing
- `QT_QPA_PLATFORM=offscreen pytest` *(fails: process hung/terminated before completing)*

------
https://chatgpt.com/codex/tasks/task_e_68bd4975f69c8332b690726c848b5af6