### PR TITLE
Apply neon effect on new editors

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1208,6 +1208,7 @@ class NeonTableWidget(QtWidgets.QTableWidget):
                 filt = NeonEventFilter(editor)
                 editor.installEventFilter(filt)
                 editor._neon_filter = filt
+                apply_neon_effect(editor, True)
         return res
 
 class ExcelCalendarTable(QtWidgets.QTableWidget):


### PR DESCRIPTION
## Summary
- Highlight cell editors immediately by applying neon effect after installing the event filter in `NeonTableWidget.edit`

## Testing
- `pytest tests/test_neon_effect.py -q`
- `pytest -q` *(fails: hung after attempting to run entire suite)*

------
https://chatgpt.com/codex/tasks/task_e_68bd9fd8fe608332918247bb59b981d4