### PR TITLE
Ensure parent UI refresh after font changes

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1916,12 +1916,11 @@ class SettingsDialog(QtWidgets.QDialog):
     def accept(self):
         self._save_config()
         theme_manager.set_text_font(self.font_text.currentFont().family())
-        parent = self.parent()
-        if parent and hasattr(parent, "table"):
-            parent.table.apply_fonts()
-            if hasattr(parent, "topbar"):
-                parent.topbar.update_labels()
         theme_manager.set_header_font(self.font_header.currentFont().family())
+        parent = self.parent()
+        if parent:
+            parent.table.apply_fonts()
+            parent.topbar.update_labels()
         super().accept()
 
     def _on_accent_changed(self, idx):


### PR DESCRIPTION
## Summary
- Update SettingsDialog.accept so table fonts and top bar labels refresh after updating both text and header fonts

## Testing
- `pytest tests/test_calendar_font_update.py::test_header_font_persists_after_month_change -q`
- `pytest tests/test_calendar_font_update.py::test_day_label_font_updates_immediately -q`
- `pytest tests/test_sidebar_font.py -q` *(fails: command interrupted or hung, further investigation needed)*

------
https://chatgpt.com/codex/tasks/task_e_68bdaec7d0648332860966b3ea3dca4b