### PR TITLE
Disable neon shadow on month label

### DIFF
--- a/app/effects.py
+++ b/app/effects.py
@@ -58,8 +58,24 @@ def set_neon(
     return eff
 
 
-def apply_neon_effect(widget: QtWidgets.QWidget, on: bool = True) -> None:
-    """Toggle neon highlight effect on *widget*."""
+def apply_neon_effect(
+    widget: QtWidgets.QWidget, on: bool = True, shadow: bool = True
+) -> None:
+    """Toggle neon highlight effect on *widget*.
+
+    Parameters
+    ----------
+    widget: QtWidgets.QWidget
+        Target widget.
+    on: bool
+        Whether to enable the effect.  When ``False`` the previous style and
+        effect (if any) are restored.
+    shadow: bool
+        If ``True`` (default) a :class:`~PySide6.QtWidgets.QGraphicsDropShadowEffect`
+        is applied.  Set to ``False`` to skip the drop shadow, keeping only the
+        color adjustments.  This is useful for widgets like ``QLabel`` where the
+        shadow is visually undesirable.
+    """
 
     if widget is None or not shiboken6.isValid(widget):
         return
@@ -78,14 +94,18 @@ def apply_neon_effect(widget: QtWidgets.QWidget, on: bool = True) -> None:
         prev_style = widget._neon_prev_style or ""
         color = widget.palette().color(QtGui.QPalette.Highlight)
         text_color = widget.palette().buttonText().color()
-        eff = QtWidgets.QGraphicsDropShadowEffect(widget)
-        eff.setOffset(0, 0)
-        eff.setBlurRadius(20)
-        eff.setColor(color)
-        try:
-            widget.setGraphicsEffect(eff)
-        except RuntimeError:
-            return
+        eff = None
+        if shadow:
+            eff = QtWidgets.QGraphicsDropShadowEffect(widget)
+            eff.setOffset(0, 0)
+            eff.setBlurRadius(20)
+            eff.setColor(color)
+            try:
+                widget.setGraphicsEffect(eff)
+            except RuntimeError:
+                return
+        else:
+            widget.setGraphicsEffect(None)
         if isinstance(widget, QtWidgets.QLabel):
             widget.setStyleSheet(
                 prev_style + f" color:{text_color.name()}; border-width:0;"

--- a/app/main.py
+++ b/app/main.py
@@ -2123,7 +2123,7 @@ class TopBar(QtWidgets.QWidget):
                 f"QToolButton{{color:{accent.name()}; border:{thickness}px solid {accent.name()}; border-radius:6px; padding:4px 10px;}}"
             )
             self.setStyleSheet(style)
-            apply_neon_effect(self.lbl_month, True)
+            apply_neon_effect(self.lbl_month, True, shadow=False)
             for w in (self.btn_prev, self.btn_next):
                 if hasattr(w, "_neon_anim") and w._neon_anim:
                     w._neon_anim.stop()
@@ -2148,6 +2148,7 @@ class TopBar(QtWidgets.QWidget):
         # Re-apply background color and ensure border is removed for the month label
         bg_color = self.lbl_month.palette().color(QtGui.QPalette.Window).name()
         self.lbl_month.setStyleSheet(f"background-color:{bg_color}; border:none;")
+        self.lbl_month.setGraphicsEffect(None)
         self.apply_fonts()
 
 


### PR DESCRIPTION
## Summary
- allow `apply_neon_effect` to skip drop shadows via new `shadow` parameter
- avoid applying drop shadow to TopBar month label and ensure it keeps a clean style

## Testing
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bedf4608ec8332ac6ec2aea6fc3b1e