### PR TITLE
Handle FocusOut in NeonEventFilter when child editor retains focus

### DIFF
--- a/tests/test_neon_editor_focus.py
+++ b/tests/test_neon_editor_focus.py
@@ -1,0 +1,53 @@
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "app"))
+
+from PySide6 import QtWidgets, QtCore
+
+import resources
+resources.register_fonts = lambda: None
+
+import app.main as main
+from app.effects import NeonEventFilter
+
+
+def test_neon_persists_during_edit_and_stops_after():
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    main.CONFIG["neon"] = True
+
+    table = QtWidgets.QTableWidget(1, 1)
+    table.setItem(0, 0, QtWidgets.QTableWidgetItem("1"))
+    table.setAttribute(QtCore.Qt.WA_Hover, True)
+    table.viewport().setAttribute(QtCore.Qt.WA_Hover, True)
+
+    filt = NeonEventFilter(table)
+    table.installEventFilter(filt)
+    table.viewport().installEventFilter(filt)
+
+    table.show()
+    table.setFocus()
+    QtWidgets.QApplication.processEvents()
+
+    assert getattr(table, "_neon_effect", None) is not None
+
+    table.editItem(table.item(0, 0))
+    QtWidgets.QApplication.processEvents()
+
+    editor = table.findChild(QtWidgets.QLineEdit)
+    assert editor is not None and editor.hasFocus()
+    assert getattr(table, "_neon_effect", None) is not None
+
+    other = QtWidgets.QLineEdit()
+    other.setAttribute(QtCore.Qt.WA_Hover, True)
+    other.show()
+    other.setFocus()
+    QtWidgets.QApplication.processEvents()
+
+    assert getattr(table, "_neon_effect", None) is None
+
+    other.close()
+    table.close()
+    app.quit()


### PR DESCRIPTION
## Summary
- keep neon highlight active when focus moves to a child widget and stop it when focus leaves the child or the entire cell
- add regression test ensuring neon persists during editing and clears on leaving editor

## Testing
- `pytest tests/test_neon_effect.py tests/test_neon_editor_focus.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bf100ee0b48332b7cd7f45d9bb2c9d