### PR TITLE
Ensure inner table headers retain selected font

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1421,6 +1421,11 @@ class ExcelCalendarTable(QtWidgets.QTableWidget):
         self.horizontalHeader().setFont(header_font)
         for tbl in self.cell_tables.values():
             tbl.horizontalHeader().setFont(header_font)
+            # Ensure individual header items also adopt the selected font
+            for i in range(tbl.columnCount()):
+                item = tbl.horizontalHeaderItem(i)
+                if item:
+                    item.setFont(header_font)
         for lbl in self.day_labels.values():
             lbl.setFont(header_font)
 

--- a/tests/test_calendar_font_update.py
+++ b/tests/test_calendar_font_update.py
@@ -53,6 +53,12 @@ def test_header_font_persists_after_month_change(tmp_path):
     assert lbl.font().family() == "DejaVu Serif"
     assert window.topbar.lbl_month.font().family() == "DejaVu Serif"
 
+    # Verify inner-table header items preserve the chosen font
+    tbl = next(iter(window.table.cell_tables.values()))
+    for i in range(tbl.columnCount()):
+        item = tbl.horizontalHeaderItem(i)
+        assert item.font().family() == "DejaVu Serif"
+
     window.close()
     app.quit()
 


### PR DESCRIPTION
## Summary
- Apply header font to each inner table header item so fonts persist across calendar navigation
- Extend calendar font tests to verify inner table headers keep chosen font

## Testing
- `pytest tests/test_calendar_font_update.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf1369b630833295d3df753fff9552