### PR TITLE
Add accent color to hover style

### DIFF
--- a/app/widgets.py
+++ b/app/widgets.py
@@ -32,6 +32,7 @@ class ButtonStyleMixin:
             thickness = 1
         return (
             f"border:{thickness}px solid {self._accent_color()}; "
+            f"color:{self._accent_color()}; "
             "background-color:rgba(255,255,255,0.08);"
         )
 


### PR DESCRIPTION
## Summary
- include button text color in hover style using accent color

## Testing
- `QT_QPA_PLATFORM=offscreen timeout 30 pytest` *(fails: tests hang after collecting 12 items)*

------
https://chatgpt.com/codex/tasks/task_e_68bf24ae3ef483329618a76582b67411