### PR TITLE
Save stats when closing dialog

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -610,8 +610,15 @@ class StatsDialog(QtWidgets.QDialog):
         self.load_stats(self.year, self.month)
 
     def closeEvent(self, event):
+        if self.current_index is not None or any(
+            self.form_stats.get_record().values()
+        ):
+            self.save_record()
         self._settings.setValue("StatsDialog/geometry", self.saveGeometry())
-        cols = [self.table_stats.columnWidth(i) for i in range(self.table_stats.columnCount())]
+        cols = [
+            self.table_stats.columnWidth(i)
+            for i in range(self.table_stats.columnCount())
+        ]
         self._settings.setValue("StatsDialog/columns", cols)
         self._settings.sync()
         super().closeEvent(event)


### PR DESCRIPTION
## Summary
- automatically persist stats entry when closing dialog with unsaved data

## Testing
- `pytest` *(fails: ImportError: libEGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68bf375edf0883329b54938b4d857cc3