### PR TITLE
Persist analytics before closing

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -765,7 +765,7 @@ class AnalyticsDialog(QtWidgets.QDialog):
         self.table.verticalHeader().setSectionResizeMode(QtWidgets.QHeaderView.Stretch)
         self._loading = False
 
-    def save(self):
+    def save(self, accept=True):
         path = os.path.join(year_dir(self.year), f"{self.year}.json")
         data = {
             "commission": self._commissions,
@@ -774,9 +774,11 @@ class AnalyticsDialog(QtWidgets.QDialog):
         }
         with open(path, "w", encoding="utf-8") as f:
             json.dump(data, f, ensure_ascii=False, indent=2)
-        self.accept()
+        if accept:
+            self.accept()
 
     def closeEvent(self, event):
+        self.save(accept=False)
         self._settings.setValue("AnalyticsDialog/geometry", self.saveGeometry())
         cols = [self.table.columnWidth(i) for i in range(self.table.columnCount())]
         self._settings.setValue("AnalyticsDialog/columns", cols)


### PR DESCRIPTION
## Summary
- Save analytics data when the dialog closes
- Allow skipping dialog accept during save to prevent double-closing

## Testing
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68bf3e0c1d688332be6f3518e5580b0e