### PR TITLE
Fix neon border effect and preserve cell size

### DIFF
--- a/app/effects.py
+++ b/app/effects.py
@@ -123,8 +123,7 @@ def apply_neon_effect(
         else:
             widget.setStyleSheet(
                 prev_style
-                + f" color:{text_color.name()};"
-                + f" border:{thickness}px solid {color.name()};"
+                + f" color:{text_color.name()}; border-color:{color.name()};"
             )
         widget._neon_effect = eff
     else:
@@ -142,7 +141,10 @@ def apply_neon_effect(
         except RuntimeError:
             pass
         prev_style = getattr(widget, "_neon_prev_style", None)
-        widget.setStyleSheet(prev_style or "")
+        if isinstance(widget, QtWidgets.QLabel):
+            widget.setStyleSheet(prev_style or "")
+        else:
+            widget.setStyleSheet((prev_style or "") + " border-color:transparent;")
         widget._neon_prev_style = None
         widget._neon_effect = None
 

--- a/app/main.py
+++ b/app/main.py
@@ -1244,6 +1244,7 @@ class NeonTableWidget(QtWidgets.QTableWidget):
             editor = self.findChild(QtWidgets.QLineEdit)
             if editor and getattr(editor, "_neon_filter", None) is None:
                 editor.setAttribute(QtCore.Qt.WA_Hover, True)
+                editor.setStyleSheet("border:1px solid transparent;")
                 filt = NeonEventFilter(editor)
                 editor.installEventFilter(filt)
                 editor._neon_filter = filt

--- a/tests/test_neon_editor_focus.py
+++ b/tests/test_neon_editor_focus.py
@@ -32,6 +32,8 @@ def test_neon_persists_during_edit_and_stops_after():
     QtWidgets.QApplication.processEvents()
 
     assert getattr(table, "_neon_effect", None) is not None
+    w_before = table.columnWidth(0)
+    h_before = table.rowHeight(0)
 
     table.editItem(table.item(0, 0))
     QtWidgets.QApplication.processEvents()
@@ -39,6 +41,8 @@ def test_neon_persists_during_edit_and_stops_after():
     editor = table.findChild(QtWidgets.QLineEdit)
     assert editor is not None and editor.hasFocus()
     assert getattr(table, "_neon_effect", None) is not None
+    assert table.columnWidth(0) == w_before
+    assert table.rowHeight(0) == h_before
 
     other = QtWidgets.QLineEdit()
     other.setAttribute(QtCore.Qt.WA_Hover, True)
@@ -47,6 +51,8 @@ def test_neon_persists_during_edit_and_stops_after():
     QtWidgets.QApplication.processEvents()
 
     assert getattr(table, "_neon_effect", None) is None
+    assert table.columnWidth(0) == w_before
+    assert table.rowHeight(0) == h_before
 
     other.close()
     table.close()

--- a/tests/test_neon_lineedit_border.py
+++ b/tests/test_neon_lineedit_border.py
@@ -1,0 +1,50 @@
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "app"))
+
+from PySide6 import QtWidgets, QtCore, QtGui
+
+import resources
+resources.register_fonts = lambda: None
+
+import app.main as main
+from app.effects import NeonEventFilter
+
+
+def test_neon_border_toggles_without_resizing():
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    main.CONFIG["neon"] = True
+
+    edit = QtWidgets.QLineEdit()
+    edit.setAttribute(QtCore.Qt.WA_Hover, True)
+    edit.setStyleSheet("border:1px solid transparent;")
+    filt = NeonEventFilter(edit)
+    edit.installEventFilter(filt)
+    edit.show()
+    edit.resize(100, 30)
+    QtWidgets.QApplication.processEvents()
+
+    size_before = edit.size()
+    edit.setFocus()
+    QtWidgets.QApplication.processEvents()
+    color = edit.palette().color(QtGui.QPalette.Highlight).name()
+    assert f"border-color:{color}" in edit.styleSheet().replace(" ", "")
+    assert edit.size() == size_before
+
+    other = QtWidgets.QLineEdit()
+    other.setAttribute(QtCore.Qt.WA_Hover, True)
+    other.setStyleSheet("border:1px solid transparent;")
+    other.installEventFilter(NeonEventFilter(other))
+    other.show()
+    other.setFocus()
+    QtWidgets.QApplication.processEvents()
+
+    assert "border-color:transparent" in edit.styleSheet().replace(" ", "")
+    assert edit.size() == size_before
+
+    other.close()
+    edit.close()
+    app.quit()


### PR DESCRIPTION
## Summary
- Maintain constant editor border width by setting base transparent border in `NeonTableWidget.edit`
- Adjust `apply_neon_effect` to only tweak border color for non-label widgets and restore transparent color on focus-out
- Add regression tests for editor focus behavior and border toggling

## Testing
- `pytest tests/test_neon_editor_focus.py tests/test_neon_lineedit_border.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c130e927bc8332b6fd06de8cb5cda9