### PR TITLE
Register fonts recursively and improve font dialog fallback

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -133,7 +133,7 @@ def ensure_font_registered(family: str, parent: QtWidgets.QWidget | None = None)
 
     If *family* is missing in :class:`QtGui.QFontDatabase`, the user is prompted to
     locate a font file. If the font cannot be loaded, the safe default
-    ``"Arial"`` is returned.
+    ``"Exo 2"`` is returned.
     """
     if family in QtGui.QFontDatabase.families():
         return family
@@ -142,7 +142,7 @@ def ensure_font_registered(family: str, parent: QtWidgets.QWidget | None = None)
         parent,
         "Выберите файл шрифта",
         "",
-        "Font Files (*.ttf *.otf)"
+        "Font Files (*.ttf *.otf *.fon *.ttc)"
     )
     if file_path:
         fid = QtGui.QFontDatabase.addApplicationFont(file_path)
@@ -154,8 +154,8 @@ def ensure_font_registered(family: str, parent: QtWidgets.QWidget | None = None)
                 return fams[0]
             logger.error("No font families found in '%s'", file_path)
 
-    logger.warning("Unable to load font '%s'; falling back to 'Arial'", family)
-    return "Arial"
+    logger.warning("Unable to load font '%s'; falling back to 'Exo 2'", family)
+    return "Exo 2"
 
 
 def resolve_font_config(parent: QtWidgets.QWidget | None = None) -> tuple[str, str]:


### PR DESCRIPTION
## Summary
- load all bundled fonts recursively and ensure Exo 2 is registered
- expand font selection dialog filter and use Exo 2 as safe fallback

## Testing
- `pytest -q` *(fails: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68c14324751c8332bc63ceca641df81c