### PR TITLE
Fix topbar month label styling with transparent background

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2470,7 +2470,7 @@ class MainWindow(QtWidgets.QMainWindow):
             f"background-color:{workspace};" + self.topbar.styleSheet()
         )
         self.topbar.lbl_month.setStyleSheet(
-            f"background-color:{workspace}; border:none;"
+            "background:transparent; border:none;"
         )
         self.topbar.spin_year.setStyleSheet(
             f"background-color:{workspace}; padding:0 6px;"
@@ -2519,6 +2519,7 @@ class MainWindow(QtWidgets.QMainWindow):
             sidebar = theme_manager.apply_monochrome(QtGui.QColor(sidebar)).name()
             accent = theme_manager.apply_monochrome(accent)
         self.sidebar.apply_style(CONFIG.get("neon", False), accent, sidebar)
+        self.topbar.apply_background(workspace)
 
     def resizeEvent(self, event):
         super().resizeEvent(event)

--- a/tests/test_settings_neon_label.py
+++ b/tests/test_settings_neon_label.py
@@ -1,0 +1,33 @@
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "app"))
+
+from PySide6 import QtWidgets
+
+import resources
+resources.register_fonts = lambda: None
+
+import app.main as main
+
+
+def test_lbl_month_keeps_neon_during_and_after_settings(monkeypatch):
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    main.CONFIG["neon"] = True
+    monkeypatch.setattr(main, "load_config", lambda: main.CONFIG)
+    window = main.MainWindow()
+
+    def fake_exec(self):
+        label = window.topbar.lbl_month
+        assert getattr(label, "_neon_effect", None) is not None
+        self.settings_changed.emit()
+        return 0
+
+    monkeypatch.setattr(main.SettingsDialog, "exec", fake_exec)
+    window.open_settings_dialog()
+    label = window.topbar.lbl_month
+    assert getattr(label, "_neon_effect", None) is not None
+    window.close()
+    app.quit()


### PR DESCRIPTION
## Summary
- make topbar month label transparent and repaint using TopBar.apply_background
- add regression test ensuring neon style persists when settings dialog opens and closes

## Testing
- `pytest` *(fails: test run did not complete, environment hung)*

------
https://chatgpt.com/codex/tasks/task_e_68c17ca68b488332a1e23679de805aa5