### PR TITLE
Ensure bundled font registration configures headers

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2546,8 +2546,9 @@ def main():
     base_family = ensure_font_registered(CONFIG.get("font_family", "Exo 2"))
     CONFIG["font_family"] = base_family
 
-    theme_manager.set_header_font(CONFIG.get("header_font", base_family))
-    theme_manager.set_text_font(CONFIG.get("text_font", base_family))
+    header_family, text_family = resolve_font_config()
+    theme_manager.set_header_font(header_family)
+    theme_manager.set_text_font(text_family)
 
     w = MainWindow()
     w.apply_settings()


### PR DESCRIPTION
## Summary
- Record Cattedrale font family during registration and persist to config
- Resolve header/text fonts at startup and apply header font globally

## Testing
- `QT_QPA_PLATFORM=offscreen python - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_68c1a50670908332ae434c5efe1b2341