### PR TITLE
Ensure calendar headers respect chosen fonts

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1457,6 +1457,11 @@ class ExcelCalendarTable(QtWidgets.QTableWidget):
             CONFIG.get("header_font", CONFIG.get("font_family", "Exo 2"))
         )
         self.horizontalHeader().setFont(header_font)
+        # Ensure weekday header items on the main calendar adopt the font
+        for i in range(self.columnCount()):
+            item = self.horizontalHeaderItem(i)
+            if item:
+                item.setFont(header_font)
         for tbl in self.cell_tables.values():
             tbl.horizontalHeader().setFont(header_font)
             # Ensure individual header items also adopt the selected font
@@ -1979,9 +1984,10 @@ class SettingsDialog(QtWidgets.QDialog):
         theme_manager.set_text_font(self.font_text.currentFont().family())
         theme_manager.set_header_font(self.font_header.currentFont().family())
         parent = self.parent()
-        if parent:
+        if parent and hasattr(parent, "table"):
             parent.table.apply_fonts()
-            parent.topbar.update_labels()
+            if hasattr(parent, "topbar"):
+                parent.topbar.update_labels()
         super().accept()
 
     def _on_accent_changed(self, idx):
@@ -2369,6 +2375,9 @@ class MainWindow(QtWidgets.QMainWindow):
             tbl.horizontalHeader().setFont(header_font)
         for lbl in self.table.day_labels.values():
             lbl.setFont(header_font)
+        # Ensure weekday headers and day labels adopt the selected font
+        # after direct font assignments above.
+        self.table.apply_fonts()
         self.sidebar.apply_fonts()
         self.table.update_day_rows()
         for dlg in app.topLevelWidgets():

--- a/tests/test_calendar_font_update.py
+++ b/tests/test_calendar_font_update.py
@@ -45,7 +45,8 @@ def test_header_font_persists_after_month_change(tmp_path):
     window = main.MainWindow()
     dlg = main.SettingsDialog(window)
     dlg.font_header.setCurrentFont(QtGui.QFont("DejaVu Serif"))
-    dlg.close()
+    # Save changes and close the dialog
+    dlg.accept()
 
     window.next_month()
     lbl = next(iter(window.table.day_labels.values()))
@@ -57,6 +58,13 @@ def test_header_font_persists_after_month_change(tmp_path):
     tbl = next(iter(window.table.cell_tables.values()))
     for i in range(tbl.columnCount()):
         item = tbl.horizontalHeaderItem(i)
+        assert item.font().family() == "DejaVu Serif"
+
+    # Weekday header labels on the main table should also use the chosen font
+    header = window.table.horizontalHeader()
+    assert header.font().family() == "DejaVu Serif"
+    for i in range(header.count()):
+        item = window.table.horizontalHeaderItem(i)
         assert item.font().family() == "DejaVu Serif"
 
     window.close()


### PR DESCRIPTION
## Summary
- Apply selected header font to calendar weekday labels
- Reapply table fonts when settings change to propagate updates
- Add regression test for persisted header fonts after saving settings

## Testing
- `pytest tests/test_calendar_font_update.py::test_day_label_font_updates_immediately -q`
- `pytest tests/test_calendar_font_update.py::test_header_font_persists_after_month_change -q`


------
https://chatgpt.com/codex/tasks/task_e_68c28694f4b48332a76cf18b5ce1479a