### PR TITLE
Align top bar year field styling with theme

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2156,7 +2156,7 @@ class TopBar(QtWidgets.QWidget):
         self.lbl_month.setPalette(pal)
         self.lbl_month.setStyleSheet("background:transparent; border:none;")
         self.spin_year.setStyleSheet(
-            f"background-color:{qcolor.name()}; padding:0 6px;"
+            f"background-color:{qcolor.name()}; padding:0 6px; border:1px solid transparent; border-radius:0;"
         )
         self.apply_fonts()
 
@@ -2495,7 +2495,7 @@ class MainWindow(QtWidgets.QMainWindow):
             "background:transparent; border:none;"
         )
         self.topbar.spin_year.setStyleSheet(
-            f"background-color:{workspace.name()}; padding:0 6px;"
+            f"background-color:{workspace.name()}; padding:0 6px; border:1px solid transparent; border-radius:0;"
         )
         theme = CONFIG.get("theme", "dark")
         self.setStyleSheet(


### PR DESCRIPTION
## Summary
- Ensure TopBar year spinbox uses transparent border with square edges
- Match MainWindow theme styling to keep spinbox consistent

## Testing
- `pytest tests/test_theme_change.py::test_lbl_month_font_and_border_on_theme_change -vv`
- `pytest tests/test_calendar_theme.py::test_calendar_status_row_colors_follow_workspace -vv`


------
https://chatgpt.com/codex/tasks/task_e_68c2987d58c08332b8ef3fbf8f42d4c5