### PR TITLE
Ensure month label and sidebar reflect header font

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2368,12 +2368,12 @@ class MainWindow(QtWidgets.QMainWindow):
         theme_manager.set_header_font(header_family)
         app = QtWidgets.QApplication.instance()
         for w in app.allWidgets():
-            if w is self.topbar.lbl_month:
-                continue
             if w is self.sidebar or self.sidebar.isAncestorOf(w):
                 continue
             w.setFont(app.font())
+        self.sidebar.apply_fonts()
         header_font = QtGui.QFont(header_family)
+        self.topbar.lbl_month.setFont(header_font)
         self.table.setFont(app.font())
         self.table.horizontalHeader().setFont(header_font)
         for tbl in self.table.cell_tables.values():
@@ -2384,7 +2384,6 @@ class MainWindow(QtWidgets.QMainWindow):
         # Ensure weekday headers and day labels adopt the selected font
         # after direct font assignments above.
         self.table.apply_fonts()
-        self.sidebar.apply_fonts()
         self.table.update_day_rows()
         for dlg in app.topLevelWidgets():
             if isinstance(dlg, QtWidgets.QDialog):

--- a/tests/test_cattedrale_font_rendering.py
+++ b/tests/test_cattedrale_font_rendering.py
@@ -1,0 +1,35 @@
+import os
+import sys
+import json
+from pathlib import Path
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "app"))
+
+from PySide6 import QtWidgets, QtGui
+
+import app.main as main
+
+
+def test_cattedrale_font_applied(tmp_path):
+    font_path = Path(__file__).resolve().parent.parent / "assets" / "fonts" / "Cattedrale[RUSbypenka220]-Regular.ttf"
+    fid = QtGui.QFontDatabase.addApplicationFont(str(font_path))
+    family = QtGui.QFontDatabase.applicationFontFamilies(fid)[0]
+
+    main.CONFIG_PATH = str(tmp_path / "config.json")
+    main.CONFIG["header_font"] = family
+    main.CONFIG["sidebar_font"] = family
+    with open(main.CONFIG_PATH, "w", encoding="utf-8") as f:
+        json.dump(main.CONFIG, f)
+
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    window = main.MainWindow()
+    window.apply_settings()
+
+    assert window.table.horizontalHeader().font().family() == family
+    assert window.topbar.lbl_month.font().family() == family
+    first_btn = window.sidebar.buttons[0]
+    assert first_btn.font().family() == family
+
+    window.close()
+    app.quit()


### PR DESCRIPTION
## Summary
- Apply selected header font to the topbar month label
- Refresh sidebar button fonts after application font changes
- Add regression test confirming Cattedrale font reaches headers, month label, and sidebar buttons

## Testing
- `pytest tests/test_cattedrale_font_rendering.py::test_cattedrale_font_applied -q` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_68c2b9ba0e4083328ff326b3e8df7fcf