### PR TITLE
Clear neon effect on editor focus out

### DIFF
--- a/tests/test_editor_neon.py
+++ b/tests/test_editor_neon.py
@@ -1,0 +1,42 @@
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "app"))
+
+from PySide6 import QtWidgets, QtCore, QtTest
+import shiboken6
+
+import resources
+resources.register_fonts = lambda: None
+
+import app.main as main
+from app import effects
+main.neon_enabled = effects.neon_enabled
+
+
+def test_editor_neon_clears():
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    main.CONFIG["neon"] = True
+    table = main.NeonTableWidget(1, 1)
+    table.setItem(0, 0, QtWidgets.QTableWidgetItem("text"))
+    table.show()
+    QtWidgets.QApplication.processEvents()
+
+    index = table.model().index(0, 0)
+    table.edit(index, QtWidgets.QAbstractItemView.DoubleClicked, None)
+    QtWidgets.QApplication.processEvents()
+
+    editor = table.findChild(QtWidgets.QLineEdit)
+    assert editor is not None
+    assert editor.graphicsEffect() is not None
+
+    table.setFocus()
+    QtWidgets.QApplication.processEvents()
+
+    assert table._active_editor is None
+    assert not shiboken6.isValid(editor) or editor.graphicsEffect() is None
+
+    table.close()
+    app.quit()


### PR DESCRIPTION
## Summary
- store active cell editor in `NeonTableWidget` and remove neon glow on focus loss
- keep day cell containers at constant `1px` transparent border
- add test ensuring editor neon clears when editing ends

## Testing
- `pytest tests/test_editor_neon.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c2cbbc8cbc83328064a38e75e48e43