### PR TITLE
Ensure neon effect uses updated gradients

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1648,6 +1648,9 @@ class CollapsibleSidebar(QtWidgets.QFrame):
         widgets = [self.btn_toggle] + self.buttons + [self.btn_settings]
         for w in widgets:
             w.apply_base_style()
+            apply_neon_effect(
+                w, w.property("neon_selected") and neon_enabled()
+            )
 
         if neon:
             for w in widgets:
@@ -2442,6 +2445,11 @@ class MainWindow(QtWidgets.QMainWindow):
         self.apply_fonts()
         self.apply_palette()
         self.apply_theme()
+        accent = QtGui.QColor(CONFIG.get("accent_color", "#39ff14"))
+        sidebar_color = CONFIG.get("sidebar_color", "#1f1f23")
+        self.sidebar.apply_style(
+            CONFIG.get("neon", False), accent, sidebar_color
+        )
 
 
 

--- a/app/widgets.py
+++ b/app/widgets.py
@@ -34,7 +34,9 @@ class ButtonStyleMixin:
 
     def apply_base_style(self) -> None:
         """Apply the base style and enable hover tracking."""
-        self.setStyleSheet(self._base_style())
+        style = self._base_style()
+        self.setStyleSheet(style)
+        self._neon_prev_style = style
         self.setCursor(QtCore.Qt.PointingHandCursor)
         self.setAttribute(QtCore.Qt.WA_Hover, True)
 


### PR DESCRIPTION
## Summary
- Cache latest base style when applying button styles
- Reapply neon effects for sidebar buttons after restyling
- Restyle sidebar from settings to update gradient colors

## Testing
- `pytest` *(fails: ImportError: libEGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68c30291922883329fcbaac08fae7526