### PR TITLE
Ensure year spinbox retains rounded style after palette changes

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2178,8 +2178,10 @@ class TopBar(QtWidgets.QWidget):
         self.lbl_month.setAutoFillBackground(False)
         self.lbl_month.setPalette(pal)
         self.lbl_month.setStyleSheet("background:transparent; border:none;")
+        # Ensure rounded spin box with transparent border regardless of palette
         self.spin_year.setStyleSheet(
-            f"background-color:{qcolor.name()}; padding:0 6px; border:1px solid transparent; border-radius:6px;"
+            f"background-color:{qcolor.name()}; padding:0 6px;"
+            " border-radius:6px; border:1px solid transparent;"
         )
         self.apply_fonts()
 
@@ -2391,6 +2393,8 @@ class MainWindow(QtWidgets.QMainWindow):
             CONFIG["gradient_colors"] = ["#39ff14", "#2d7cdb"]
         BASE_SAVE_PATH = os.path.abspath(CONFIG.get("save_path", DATA_DIR))
         self.apply_settings()
+        workspace = QtGui.QColor(CONFIG.get("workspace_color", "#1e1e21"))
+        self.topbar.apply_background(workspace)
 
     def apply_fonts(self):
         header_family, text_family = resolve_font_config(self)
@@ -2452,6 +2456,11 @@ class MainWindow(QtWidgets.QMainWindow):
         self.sidebar.anim.setDuration(160)
         update_neon_filters(self)
         self.topbar.apply_background(workspace)
+        # explicitly reapply style so QSpinBox keeps rounded transparent border
+        self.topbar.spin_year.setStyleSheet(
+            f"background-color:{workspace.name()}; padding:0 6px;"
+            " border-radius:6px; border:1px solid transparent;"
+        )
         self.topbar.update_labels()
 
     def apply_settings(self):

--- a/tests/test_year_spinbox_style.py
+++ b/tests/test_year_spinbox_style.py
@@ -1,0 +1,39 @@
+import os
+import sys
+import json
+from pathlib import Path
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "app"))
+
+from PySide6 import QtWidgets
+
+import resources
+resources.register_fonts = lambda: None
+
+import app.main as main
+
+
+def test_year_spinbox_border_persists(tmp_path):
+    # Use temporary config file
+    main.CONFIG_PATH = str(tmp_path / "config.json")
+    with open(main.CONFIG_PATH, "w", encoding="utf-8") as f:
+        json.dump(main.CONFIG, f)
+
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    window = main.MainWindow()
+    window.apply_settings()
+
+    # change workspace color and simulate settings save
+    main.CONFIG["workspace_color"] = "#123456"
+    with open(main.CONFIG_PATH, "w", encoding="utf-8") as f:
+        json.dump(main.CONFIG, f)
+
+    window._on_settings_changed()
+
+    style = window.topbar.spin_year.styleSheet().replace(" ", "")
+    assert "border-radius:6px" in style
+    assert "border:1pxsolidtransparent" in style
+
+    window.close()
+    app.quit()


### PR DESCRIPTION
## Summary
- Keep TopBar year QSpinBox rounded with transparent border in apply_background
- Reapply rounded QSpinBox style in apply_palette and after settings changes
- Add regression test for year spinbox border style persistence

## Testing
- `pytest tests/test_year_spinbox_style.py -q` *(fails: process hung in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c39cd530a88332bf9c5a4eea139427