### PR TITLE
Use border-only neon effect for table editors

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1249,7 +1249,7 @@ class NeonTableWidget(QtWidgets.QTableWidget):
                 filt = NeonEventFilter(editor)
                 editor.installEventFilter(filt)
                 editor._neon_filter = filt
-                apply_neon_effect(editor, True)
+                apply_neon_effect(editor, True, shadow=False)
                 if self._active_editor is not None and self._active_editor is not editor:
                     self._active_editor.removeEventFilter(self)
                     apply_neon_effect(self._active_editor, False)
@@ -1259,7 +1259,7 @@ class NeonTableWidget(QtWidgets.QTableWidget):
 
     def eventFilter(self, obj, event):  # noqa: D401 - Qt event filter signature
         if obj is self._active_editor and event.type() == QtCore.QEvent.FocusOut:
-            apply_neon_effect(self._active_editor, False)
+            apply_neon_effect(obj, False)
             obj.removeEventFilter(self)
             self._active_editor = None
         return super().eventFilter(obj, event)
@@ -1403,13 +1403,13 @@ class ExcelCalendarTable(QtWidgets.QTableWidget):
         self.cell_containers.clear()
         self.cell_filters.clear()
         self.setRowCount(len(weeks))
+        base_style = "border:1px solid transparent;"
         for r, week in enumerate(weeks):
             for c, day in enumerate(week):
                 container = QtWidgets.QWidget()
                 lay = QtWidgets.QVBoxLayout(container)
                 lay.setContentsMargins(0, 0, 0, 0)
                 lay.setSpacing(2)
-                base_style = "border:1px solid transparent;"
                 container.setStyleSheet(base_style)
                 lbl = QtWidgets.QLabel(str(day.day), container)
                 lbl.setFont(

--- a/tests/test_editor_neon.py
+++ b/tests/test_editor_neon.py
@@ -5,7 +5,7 @@ from pathlib import Path
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "app"))
 
-from PySide6 import QtWidgets, QtCore, QtTest
+from PySide6 import QtWidgets, QtCore, QtTest, QtGui
 import shiboken6
 
 import resources
@@ -30,13 +30,15 @@ def test_editor_neon_clears():
 
     editor = table.findChild(QtWidgets.QLineEdit)
     assert editor is not None
-    assert editor.graphicsEffect() is not None
+    color = editor.palette().color(QtGui.QPalette.Highlight).name()
+    assert f"border-color:{color}" in editor.styleSheet().replace(" ", "")
 
     table.setFocus()
     QtWidgets.QApplication.processEvents()
 
     assert table._active_editor is None
-    assert not shiboken6.isValid(editor) or editor.graphicsEffect() is None
+    if shiboken6.isValid(editor):
+        assert "border-color:transparent" in editor.styleSheet().replace(" ", "")
 
     table.close()
     app.quit()


### PR DESCRIPTION
## Summary
- apply border-only neon effect to active cell editors and clear it on focus out
- preset day cell containers with transparent borders to avoid layout shifts
- update tests to verify border color changes instead of graphics effects

## Testing
- `pytest tests/test_editor_neon.py::test_editor_neon_clears -q`
- `pytest tests/test_neon_lineedit_border.py tests/test_neon_effect.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3ad4049108332959f1ce82dad9b9d