### PR TITLE
Add customtkinter dependency and fix font registration

### DIFF
--- a/app/resources.py
+++ b/app/resources.py
@@ -6,6 +6,7 @@ import os
 import logging
 import ctypes
 import tkinter as tk
+from tkinter import font as tkfont
 from typing import Dict
 
 import customtkinter as ctk
@@ -28,9 +29,14 @@ def register_cattedrale(font_path: str) -> str:
 
     root = tk.Tk()
     root.withdraw()
-    ctk_font = ctk.CTkFont(file=font_path)
-    family = ctk_font.cget("family")
-    root.destroy()
+    try:
+        before = set(tkfont.families(root))
+        ctk.FontManager.load_font(font_path)
+        after = set(tkfont.families(root))
+        new_fams = after - before
+        family = next(iter(new_fams), os.path.splitext(os.path.basename(font_path))[0])
+    finally:
+        root.destroy()
     return family
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 PySide6==6.9.2
 bump2version==1.0.1
 pyinstaller==6.15.0
+customtkinter==5.2.2


### PR DESCRIPTION
## Summary
- add `customtkinter` to dependencies
- update font registration logic to use `FontManager` and avoid deprecated API

## Testing
- `xvfb-run --auto-servernum --server-args='-screen 0 1024x768x24' env QT_QPA_PLATFORM=offscreen timeout 5 python app/main.py`
- `timeout 5 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c3c3a394d08332829afb84bbd39272