### PR TITLE
Show application errors immediately in run script

### DIFF
--- a/run.py
+++ b/run.py
@@ -35,13 +35,9 @@ def main() -> int:
 
     result = subprocess.run(
         [str(PYTHON), '-X', 'faulthandler', str(ROOT / 'app' / 'main.py')],
-        stderr=subprocess.PIPE,
-        text=True,
         check=False,
     )
     if result.returncode != 0:
-        if result.stderr:
-            print(result.stderr, file=sys.stderr, end="")
         print(
             f"Application failed with exit code {result.returncode}",
             file=sys.stderr,


### PR DESCRIPTION
## Summary
- remove stderr capture when launching app so errors display immediately

## Testing
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c3d9148b648332b7c7fa583613f061