### PR TITLE
Skip font registration without display

### DIFF
--- a/app/resources.py
+++ b/app/resources.py
@@ -41,6 +41,13 @@ def register_cattedrale(font_path: str) -> str:
         )
         return "Exo 2"
 
+    if not os.environ.get("DISPLAY"):
+        logger.warning(
+            "Skipping custom font registration for '%s': DISPLAY environment variable not set",
+            font_path,
+        )
+        return "Exo 2"
+
     root = None
     try:
         if os.name == "nt":


### PR DESCRIPTION
## Summary
- Avoid registering Cattedrale font when `DISPLAY` is missing
- Warn when skipping registration due to headless environment

## Testing
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68c3fc3021fc8332ada0eef42a9b905b