### PR TITLE
Ensure StyledToolButton styling updates globally

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1532,12 +1532,12 @@ class CollapsibleSidebar(QtWidgets.QFrame):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.setObjectName("Sidebar")
-        self.setStyleSheet("""
+        self.setStyleSheet(
+            """
             #Sidebar { background-color: #1f1f23; }
-            QToolButton { color: white; border: none; padding: 10px; border-radius: 8px; }
-            QToolButton:hover { background-color: rgba(255,255,255,0.08); }
             QLabel { color: #c7c7c7; }
-        """)
+            """
+        )
         self.expanded_width=260; self.collapsed_width=64
         lay=QtWidgets.QVBoxLayout(self); lay.setContentsMargins(8,8,8,8); lay.setSpacing(6)
 
@@ -2461,8 +2461,14 @@ class MainWindow(QtWidgets.QMainWindow):
         self.sidebar.apply_style(
             CONFIG.get("neon", False), accent, sidebar_color
         )
-
-
+        app = QtWidgets.QApplication.instance()
+        neon = CONFIG.get("neon", False)
+        for w in app.allWidgets():
+            if isinstance(w, StyledToolButton):
+                w.apply_base_style()
+                selected = w.property("neon_selected")
+                on = neon if selected is None else bool(selected) and neon
+                apply_neon_effect(w, on)
 
 
 

--- a/app/widgets.py
+++ b/app/widgets.py
@@ -25,7 +25,8 @@ class ButtonStyleMixin:
         x2 = 0.5 + 0.5 * math.cos(rad)
         y2 = 0.5 + 0.5 * math.sin(rad)
         return (
-            "border-radius:16px; padding:8px 12px; "
+            "border-radius:16px; "
+            "padding-top:8px; padding-bottom:8px; padding-left:12px; padding-right:12px; "
             f"border:{thickness}px solid transparent; min-width:24px; min-height:24px; "
             "color:white; "
             f"background: qlineargradient(x1:0,y1:0,x2:{x2:.2f},y2:{y2:.2f}, "

--- a/tests/test_button_style_persistence.py
+++ b/tests/test_button_style_persistence.py
@@ -1,0 +1,49 @@
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "app"))
+
+from PySide6 import QtWidgets
+
+import resources
+resources.register_fonts = lambda: None
+
+import app.main as main
+from widgets import StyledToolButton
+
+
+def test_gradient_and_neon_persist_across_buttons_and_dialog(monkeypatch):
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    window = main.MainWindow()
+    window.sidebar.activate_button(window.sidebar.buttons[0])
+
+    dlg = QtWidgets.QDialog()
+    btn_dialog = StyledToolButton(dlg)
+    btn_dialog.setText("Dlg")
+    QtWidgets.QVBoxLayout(dlg).addWidget(btn_dialog)
+
+    main.CONFIG["gradient_colors"] = ["#123456", "#654321"]
+    main.CONFIG["neon"] = True
+    monkeypatch.setattr(main, "load_config", lambda: main.CONFIG)
+
+    window.apply_settings()
+
+    grad = main.CONFIG["gradient_colors"]
+    targets = [window.sidebar.buttons[0], window.topbar.btn_prev, btn_dialog]
+    for b in targets:
+        style = b.styleSheet().lower()
+        assert f"stop:0 {grad[0].lower()}" in style
+        assert f"stop:1 {grad[1].lower()}" in style
+        assert b.graphicsEffect() is not None
+
+    dlg.close()
+
+    sidebar_btn = window.sidebar.buttons[0]
+    style = sidebar_btn.styleSheet().lower()
+    assert f"stop:0 {grad[0].lower()}" in style
+    assert sidebar_btn.graphicsEffect() is not None
+
+    window.close()
+    app.quit()


### PR DESCRIPTION
## Summary
- Remove sidebar stylesheet rules for `QToolButton` so each button manages its own style
- Reapply base styles and neon effects to every `StyledToolButton` from `apply_settings`
- Add explicit padding in button mixin for consistent spacing
- Test that gradient/neon changes persist on buttons even after dialogs are opened

## Testing
- `pytest tests/test_button_style_persistence.py -q` *(hung: no output)*

------
https://chatgpt.com/codex/tasks/task_e_68c44515ad3883329fadeb1ee7b6a1da