### PR TITLE
Improve font registration feedback and config updates

### DIFF
--- a/tests/test_register_cattedrale_error_dialog.py
+++ b/tests/test_register_cattedrale_error_dialog.py
@@ -1,0 +1,23 @@
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "app"))
+
+from PySide6 import QtWidgets
+import resources
+
+
+def test_register_cattedrale_error_dialog(monkeypatch):
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    called = {}
+    monkeypatch.setattr(resources, "tk", None)
+    monkeypatch.setattr(resources, "ctk", None)
+    monkeypatch.setattr(resources, "tkfont", None)
+    monkeypatch.setattr(QtWidgets.QMessageBox, "critical", lambda *a, **k: called.setdefault("called", True))
+
+    fam = resources.register_cattedrale("dummy.ttf")
+    assert fam == "Exo 2"
+    assert called.get("called")
+    app.quit()


### PR DESCRIPTION
## Summary
- Show error dialog when Tk or customtkinter are unavailable or DISPLAY missing
- Update header and sidebar font settings from registered Cattedrale family and reapply fonts
- Add test covering error dialog on missing Tk modules

## Testing
- `pytest tests/test_register_cattedrale_error_dialog.py`

------
https://chatgpt.com/codex/tasks/task_e_68c464850ff4833294c4bdd4eb7553ca