### PR TITLE
Adjust neon button padding and style reset

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1608,8 +1608,10 @@ class CollapsibleSidebar(QtWidgets.QFrame):
             b.setProperty("neon_selected", selected)
             b.apply_base_style()
             b._apply_hover(selected)
-            b._neon_prev_style = b.styleSheet()
             apply_neon_effect(b, selected and neon_enabled())
+
+        for b in self.buttons:
+            b._neon_prev_style = b.styleSheet()
 
     def set_collapsed(self, collapsed: bool):
         self._collapsed = collapsed

--- a/app/widgets.py
+++ b/app/widgets.py
@@ -24,12 +24,14 @@ class ButtonStyleMixin:
         rad = math.radians(angle)
         x2 = 0.5 + 0.5 * math.cos(rad)
         y2 = 0.5 + 0.5 * math.sin(rad)
+        pad_v = max(0, 8 - thickness)
+        pad_h = max(0, 12 - thickness)
         return (
-            "border-radius:16px; "
-            "padding-top:8px; padding-bottom:8px; padding-left:12px; padding-right:12px; "
-            f"border:{thickness}px solid transparent; min-width:24px; min-height:24px; "
-            "color:white; "
-            f"background: qlineargradient(x1:0,y1:0,x2:{x2:.2f},y2:{y2:.2f}, "
+            "border-radius:16px;"
+            f"padding:{pad_v}px {pad_h}px;"
+            f"border:{thickness}px solid transparent; min-width:24px; min-height:24px;"
+            "color:white;"
+            f"background: qlineargradient(x1:0,y1:0,x2:{x2:.2f},y2:{y2:.2f},"
             f"stop:0 {grad[0]}, stop:1 {grad[1]});"
         )
 


### PR DESCRIPTION
## Summary
- Compute button padding based on neon border thickness to keep size consistent
- Save each button's current style after activation for accurate neon restoration

## Testing
- `pytest` *(fails: ImportError libEGL.so.1 / timed out after setup)*

------
https://chatgpt.com/codex/tasks/task_e_68c47bbba8748332b0d3b3a126653314