### PR TITLE
Handle Windows without DISPLAY requirement

### DIFF
--- a/app/resources.py
+++ b/app/resources.py
@@ -48,7 +48,7 @@ def register_cattedrale(font_path: str) -> str:
         QtWidgets.QMessageBox.critical(None, "Ошибка", msg)
         return "Exo 2"
 
-    if not os.environ.get("DISPLAY"):
+    if os.name != "nt" and not os.environ.get("DISPLAY"):
         msg = (
             "Переменная окружения DISPLAY не установлена — шрифт Cattedrale не будет применён"
         )


### PR DESCRIPTION
## Summary
- Skip DISPLAY environment check on Windows so Tk font registration can run

## Testing
- `pytest tests/test_register_cattedrale_error_dialog.py -q`
- `pytest tests/test_startup.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4f13240348332972881695819c1b2