### PR TITLE
Ensure StyledToolButton refreshes on gradient change

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2464,13 +2464,13 @@ class MainWindow(QtWidgets.QMainWindow):
             CONFIG.get("neon", False), accent, sidebar_color
         )
         app = QtWidgets.QApplication.instance()
-        neon = CONFIG.get("neon", False)
         for w in app.allWidgets():
             if isinstance(w, StyledToolButton):
                 w.apply_base_style()
-                selected = w.property("neon_selected")
-                on = neon if selected is None else bool(selected) and neon
-                apply_neon_effect(w, on)
+                w._neon_prev_style = w.styleSheet()
+                apply_neon_effect(
+                    w, w.property("neon_selected") and neon_enabled()
+                )
 
 
 

--- a/tests/test_button_style_persistence.py
+++ b/tests/test_button_style_persistence.py
@@ -36,14 +36,26 @@ def test_gradient_and_neon_persist_across_buttons_and_dialog(monkeypatch):
         style = b.styleSheet().lower()
         assert f"stop:0 {grad[0].lower()}" in style
         assert f"stop:1 {grad[1].lower()}" in style
-        assert b.graphicsEffect() is not None
+
+    # only the activated sidebar button should have a neon effect
+    assert window.sidebar.buttons[0].graphicsEffect() is not None
+    assert window.topbar.btn_prev.graphicsEffect() is None
+    assert btn_dialog.graphicsEffect() is None
 
     dlg.close()
+
+    # Reopen a dialog to ensure sidebar retains updated gradient
+    dlg = QtWidgets.QDialog()
+    btn_dialog = StyledToolButton(dlg)
+    btn_dialog.setText("Dlg")
+    QtWidgets.QVBoxLayout(dlg).addWidget(btn_dialog)
+    window.apply_settings()
 
     sidebar_btn = window.sidebar.buttons[0]
     style = sidebar_btn.styleSheet().lower()
     assert f"stop:0 {grad[0].lower()}" in style
     assert sidebar_btn.graphicsEffect() is not None
 
+    dlg.close()
     window.close()
     app.quit()


### PR DESCRIPTION
## Summary
- Reapply base styling and neon effect to all StyledToolButton widgets after settings changes
- Update test to verify gradient refresh and neon behavior when dialogs reopen

## Testing
- `pytest tests/test_button_style_persistence.py -q` *(failed: command hung; manual interruption required)*

------
https://chatgpt.com/codex/tasks/task_e_68c54a27088483328c2b735a6d2707d8