### PR TITLE
fix sidebar button hover after theme change

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1664,6 +1664,7 @@ class CollapsibleSidebar(QtWidgets.QFrame):
         widgets = [self.btn_toggle] + self.buttons + [self.btn_settings]
         for w in widgets:
             w.apply_base_style()
+            w._apply_hover(w.property("neon_selected"))
             apply_neon_effect(
                 w, w.property("neon_selected") and neon_enabled()
             )


### PR DESCRIPTION
## Summary
- ensure CollapsibleSidebar buttons restore hover state when applying style
- call apply_neon_effect after restoring hover

## Testing
- `pytest -q` *(fails: libEGL.so.1: cannot open shared object file)*
- `python - <<'PY'
import os, sys
os.environ['QT_QPA_PLATFORM']='offscreen'
sys.path.append('app')
from main import CollapsibleSidebar
from PySide6 import QtWidgets, QtGui
app = QtWidgets.QApplication([])
sidebar = CollapsibleSidebar()
btn = sidebar.buttons[0]
btn.setProperty('neon_selected', True)
sidebar.apply_style(neon=True, accent=QtGui.QColor('#ff0000'))
btn._apply_hover(True)
print('after manual hover:', btn.styleSheet())
PY`

------
https://chatgpt.com/codex/tasks/task_e_68c5e8df6ab88332aa106e5439f0f42e