### PR TITLE
Ensure UI size and column preferences persist

### DIFF
--- a/app/effects.py
+++ b/app/effects.py
@@ -6,10 +6,11 @@ import weakref
 
 def neon_enabled() -> bool:
     """Return ``True`` if neon highlighting is enabled in the configuration."""
-
     try:  # local import to avoid circular dependency on ``main`` during startup
-        from . import main
-
+        import importlib, sys
+        main = sys.modules.get("app.main") or sys.modules.get("main")
+        if main is None:  # pragma: no cover - fallback
+            main = importlib.import_module("main")
         return bool(getattr(main, "CONFIG", {}).get("neon", False))
     except Exception:
         return False
@@ -95,8 +96,10 @@ def apply_neon_effect(
         color = widget.palette().color(QtGui.QPalette.Highlight)
         text_color = widget.palette().buttonText().color()
         try:  # local import to avoid circular dependency on ``main``
-            from . import main
-
+            import importlib, sys
+            main = sys.modules.get("app.main") or sys.modules.get("main")
+            if main is None:  # pragma: no cover - fallback
+                main = importlib.import_module("main")
             thickness = int(
                 getattr(main, "CONFIG", {}).get("neon_thickness", 1)
             )

--- a/app/widgets.py
+++ b/app/widgets.py
@@ -12,8 +12,10 @@ class ButtonStyleMixin:
     def _base_style(self) -> str:
         """Build the base style using current configuration."""
         try:
-            from . import main  # type: ignore
-
+            import importlib, sys
+            main = sys.modules.get("app.main") or sys.modules.get("main")
+            if main is None:  # pragma: no cover - fallback
+                main = importlib.import_module("main")
             thickness = main.CONFIG.get("neon_thickness", 1)
             grad = main.CONFIG.get("gradient_colors", ["#39ff14", "#2d7cdb"])
             angle = main.CONFIG.get("gradient_angle", 0)

--- a/tests/test_dialog_persistence.py
+++ b/tests/test_dialog_persistence.py
@@ -1,0 +1,69 @@
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from PySide6 import QtWidgets, QtCore
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "app"))
+
+import resources  # noqa: E402
+
+resources.register_fonts = lambda: None
+
+import app.main as main  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        lambda parent: main.StatsDialog(2024, 1, parent),
+        lambda parent: main.AnalyticsDialog(2024, parent),
+        lambda parent: main.ReleaseDialog(2024, 1, [], parent),
+        lambda parent: main.TopDialog(2024, parent),
+        lambda parent: main.SettingsDialog(parent),
+    ],
+)
+def test_dialog_geometry_persist(tmp_path, monkeypatch, factory):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    main.BASE_SAVE_PATH = str(tmp_path / "data")
+    main.CONFIG["save_path"] = main.BASE_SAVE_PATH
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    dlg = factory(None)
+    size = QtCore.QSize(640, 480)
+    dlg.resize(size)
+    dlg.show()
+    app.processEvents()
+    expected = dlg.size()
+    dlg.close()
+    app.processEvents()
+    dlg2 = factory(None)
+    dlg2.show()
+    app.processEvents()
+    assert dlg2.size() == expected
+    dlg2.close()
+    app.quit()
+
+
+def test_calendar_columns_persist(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    main.BASE_SAVE_PATH = str(tmp_path / "data")
+    main.CONFIG["save_path"] = main.BASE_SAVE_PATH
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    window = main.MainWindow()
+    # Adjust inner day table column widths via header resizing
+    inner = next(iter(window.table.cell_tables.values()))
+    header = inner.horizontalHeader()
+    header.resizeSection(0, 70)
+    header.resizeSection(1, 80)
+    header.resizeSection(2, 90)
+    app.processEvents()
+    window.close()
+    app.processEvents()
+    window2 = main.MainWindow()
+    widths = window2.table.get_day_column_widths()
+    assert widths[:3] == [70, 80, 90]
+    window2.close()
+    app.quit()
+


### PR DESCRIPTION
## Summary
- Make sidebar styling resilient to monkeypatching and update workspace color across top bar and status bar
- Resolve main config reliably in widgets and neon helpers
- Add tests verifying dialog geometry and calendar column width persistence

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c68ac2ec388332b7624ee524ab9456