### PR TITLE
feat: persist sidebar state

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -42,6 +42,7 @@ def load_config():
         "sidebar_color": "#1f1f23",
         "sidebar_icon": os.path.join(ASSETS, "gpt_icon.png"),
         "app_icon": os.path.join(ASSETS, "gpt_icon.png"),
+        "sidebar_collapsed": False,
     }
     if os.path.exists(CONFIG_PATH):
         try:
@@ -1621,13 +1622,17 @@ class CollapsibleSidebar(QtWidgets.QFrame):
         lay.addStretch(1)
         lay.addWidget(self.btn_settings)
 
-        self._collapsed = False
+        self._collapsed = CONFIG.get("sidebar_collapsed", False)
         self.anim = QtCore.QPropertyAnimation(self, b"maximumWidth", self)
         self.anim.setDuration(160)
         self.setMinimumWidth(self.collapsed_width)
         self.setMaximumWidth(self.expanded_width)
         self.update_icons()
         self.apply_fonts()
+        if self._collapsed:
+            self.anim.setDuration(0)
+            self.set_collapsed(True)
+            self.anim.setDuration(160)
 
     def activate_button(self, btn: QtWidgets.QToolButton) -> None:
         for b in self.buttons:
@@ -1652,6 +1657,12 @@ class CollapsibleSidebar(QtWidgets.QFrame):
             b.setToolButtonStyle(
                 QtCore.Qt.ToolButtonIconOnly if collapsed else QtCore.Qt.ToolButtonTextBesideIcon
             )
+        CONFIG["sidebar_collapsed"] = collapsed
+        try:
+            with open(CONFIG_PATH, "w", encoding="utf-8") as f:
+                json.dump(CONFIG, f, ensure_ascii=False, indent=2)
+        except Exception:
+            pass
         self.toggled.emit(not collapsed)
 
     def toggle(self): self.set_collapsed(not self._collapsed)


### PR DESCRIPTION
## Summary
- save sidebar collapsed state in config and restore on startup

## Testing
- `QT_QPA_PLATFORM=offscreen python3 - <<'PY'
import sys, json
sys.path.append('app')
import main
from main import CollapsibleSidebar, CONFIG, CONFIG_PATH
from PySide6 import QtWidgets
app = QtWidgets.QApplication([])
sidebar = CollapsibleSidebar()
print('initial', sidebar._collapsed)
sidebar.toggle()
print('toggled', sidebar._collapsed)
app.quit()
with open(CONFIG_PATH, 'r', encoding='utf-8') as f:
    data = json.load(f)
print('saved', data.get('sidebar_collapsed'))
PY`
- `QT_QPA_PLATFORM=offscreen python3 - <<'PY'
import sys, json
sys.path.append('app')
import main
from main import CollapsibleSidebar, CONFIG_PATH
from PySide6 import QtWidgets
with open(CONFIG_PATH,'r',encoding='utf-8') as f:
    data = json.load(f)
print('config_before', data.get('sidebar_collapsed'))
app = QtWidgets.QApplication([])
sidebar = CollapsibleSidebar()
print('new_sidebar_collapsed', sidebar._collapsed)
PY`
- `QT_QPA_PLATFORM=offscreen pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c68e55158883329fb77ba036fc0e55