### PR TITLE
Refresh StyledPushButton styling on settings apply

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2503,11 +2503,12 @@ class MainWindow(QtWidgets.QMainWindow):
         )
         app = QtWidgets.QApplication.instance()
         for w in app.allWidgets():
-            if isinstance(w, StyledToolButton):
+            if isinstance(w, (StyledToolButton, StyledPushButton)):
                 w.apply_base_style()
                 w._neon_prev_style = w.styleSheet()
                 apply_neon_effect(
-                    w, w.property("neon_selected") and neon_enabled()
+                    w,
+                    bool(w.property("neon_selected")) and neon_enabled(),
                 )
 
 


### PR DESCRIPTION
## Summary
- Re-apply base style and neon effect to all StyledPushButton widgets when settings change

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c6a55595948332be879562c10d0406