### PR TITLE
Enable neon highlight by default

### DIFF
--- a/data/config.json
+++ b/data/config.json
@@ -1,5 +1,5 @@
 {
-  "neon": false,
+  "neon": true,
   "neon_size": 10,
   "neon_thickness": 1,
   "neon_intensity": 255,


### PR DESCRIPTION
## Summary
- enable neon effects in the default configuration

## Testing
- `pytest -q`
- `QT_QPA_PLATFORM=offscreen timeout 5 python app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6b0f86da48332a95ef3526d45ee39