### PR TITLE
Adjust neon hover stop behavior

### DIFF
--- a/app/effects.py
+++ b/app/effects.py
@@ -203,7 +203,8 @@ class NeonEventFilter(QtCore.QObject):
             QtCore.QEvent.HoverLeave,
             QtCore.QEvent.Leave,
         ):
-            self._stop()
+            if not widget.hasFocus():
+                self._stop()
 
         return False
 


### PR DESCRIPTION
## Summary
- avoid stopping the neon effect on hover leave while the widget still has focus so focus-out handling continues to disable it

## Testing
- pytest *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68c85d7cf5908332a309ce73c2395c70