### PR TITLE
Limit neon hover effect to table viewport

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1257,13 +1257,11 @@ class NeonTableWidget(QtWidgets.QTableWidget):
     def __init__(self, rows, cols, parent=None, use_neon=True):
         super().__init__(rows, cols, parent)
         self.setFocusPolicy(QtCore.Qt.StrongFocus)
-        self.setAttribute(QtCore.Qt.WA_Hover, True)
         self.viewport().setAttribute(QtCore.Qt.WA_Hover, True)
         self._neon_filter = None
         self._active_editor: QtWidgets.QLineEdit | None = None
         if use_neon and neon_enabled(CONFIG):
             self._neon_filter = NeonEventFilter(self, CONFIG)
-            self.installEventFilter(self._neon_filter)
             self.viewport().installEventFilter(self._neon_filter)
         self.setStyleSheet(
             "QTableWidget, QTableWidget::viewport{border:1px solid transparent;}\n"


### PR DESCRIPTION
## Summary
- restrict the neon hover attribute to the table viewport
- install the neon event filter only on the viewport so headers stay unaffected

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c85f11c9548332aabb86fba5581f88