### PR TITLE
Adjust neon effect activation

### DIFF
--- a/app/effects.py
+++ b/app/effects.py
@@ -157,6 +157,8 @@ class NeonEventFilter(QtCore.QObject):
         if not neon_enabled(self._config):
             return
         widget = self._widget()
+        if getattr(widget, "_neon_effect", None):
+            return
         apply_neon_effect(widget, True, config=self._config)
 
     def _stop(self) -> None:
@@ -178,7 +180,6 @@ class NeonEventFilter(QtCore.QObject):
         etype = event.type()
 
         if etype in (
-            QtCore.QEvent.HoverEnter,
             QtCore.QEvent.FocusIn,
             QtCore.QEvent.MouseButtonDblClick,
         ):


### PR DESCRIPTION
## Summary
- skip reapplying the neon effect when it is already active on a widget
- limit neon activation events to focus and double-click interactions

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68c8639382a883329c3a59c98cab42a9