### PR TITLE
Disable hover styling on Excel calendar headers

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1321,7 +1321,17 @@ class ExcelCalendarTable(QtWidgets.QTableWidget):
         day_names = ["ПН", "ВТ", "СР", "ЧТ", "ПТ", "СБ", "ВС"]
         self.setColumnCount(len(day_names))
         self.setHorizontalHeaderLabels(day_names)
-        self.horizontalHeader().setSectionResizeMode(QtWidgets.QHeaderView.Stretch)
+        header = self.horizontalHeader()
+        header.setAttribute(QtCore.Qt.WA_Hover, False)
+        if getattr(header, "_neon_filter", None):
+            header.removeEventFilter(header._neon_filter)
+            header._neon_filter = None
+        base = CONFIG.get("workspace_color", "#1e1e21")
+        header.setStyleSheet(
+            f"QHeaderView::section{{background:{base}; padding:0 6px;}}"
+            f"QHeaderView::section:hover{{background:{base};}}"
+        )
+        header.setSectionResizeMode(QtWidgets.QHeaderView.Stretch)
         self.verticalHeader().setSectionResizeMode(QtWidgets.QHeaderView.Stretch)
         self.setSelectionMode(QtWidgets.QAbstractItemView.NoSelection)
         self.setFocusPolicy(QtCore.Qt.NoFocus)


### PR DESCRIPTION
## Summary
- disable hover attributes and remove neon event filters from the Excel calendar header to prevent hover-triggered filtering
- lock the header background color to the configured workspace color for consistent styling

## Testing
- python -m compileall app/main.py

------
https://chatgpt.com/codex/tasks/task_e_68c86d2ca80c83328150ea923beb63fa