### PR TITLE
Remove toolbar button stylesheet overrides

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2632,8 +2632,6 @@ class MainWindow(QtWidgets.QMainWindow):
         )
         theme = CONFIG.get("theme", "dark")
         self.setStyleSheet(
-            "QPushButton,QToolButton{" + base + "}"
-            "QPushButton:hover,QToolButton:hover{" + flat_base + "}"
             "QSpinBox,QDoubleSpinBox,QTimeEdit,QComboBox,QLineEdit{" + flat_base + "}"
             f"""
             QSpinBox::up-button,QDoubleSpinBox::up-button{{


### PR DESCRIPTION
## Summary
- remove the QPushButton and QToolButton base and hover stylesheet overrides in `MainWindow.apply_style`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c86e8613348332b78a40c7ae64168f