### PR TITLE
Adjust neon effect toggling for nav buttons

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2272,7 +2272,11 @@ class TopBar(QtWidgets.QWidget):
         for btn in (self.btn_prev, self.btn_next):
             btn.apply_base_style()
             btn._apply_hover(bool(btn.property("neon_selected")))
-            apply_neon_effect(btn, neon, config=CONFIG)
+            apply_neon_effect(
+                btn,
+                btn.property("neon_selected") and neon,
+                config=CONFIG,
+            )
 
         self.apply_fonts()
         self._update_spin_year_neon(neon)


### PR DESCRIPTION
## Summary
- apply the neon effect to navigation buttons only when their hover property is active

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c86f63c6b48332a8b5a99010adcde1