### PR TITLE
Add focus state styling to color buttons

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2097,7 +2097,9 @@ class SettingsDialog(QtWidgets.QDialog):
     def _update_workspace_button(self):
         color = self._workspace_color.name()
         self.btn_workspace.setStyleSheet(
-            f"QPushButton{{background:{color}; border:1px solid #555;}} QPushButton:hover{{background:{color};}}"
+            f"QPushButton{{background:{color}; border:1px solid #555;}} "
+            f"QPushButton:hover{{background:{color};}} "
+            f"QPushButton:focus{{background:{color};}}"
         )
 
     def choose_workspace_color(self):
@@ -2122,7 +2124,9 @@ class SettingsDialog(QtWidgets.QDialog):
     def _update_sidebar_button(self):
         color = self._sidebar_color.name()
         self.btn_sidebar.setStyleSheet(
-            f"QPushButton{{background:{color}; border:1px solid #555;}} QPushButton:hover{{background:{color};}}"
+            f"QPushButton{{background:{color}; border:1px solid #555;}} "
+            f"QPushButton:hover{{background:{color};}} "
+            f"QPushButton:focus{{background:{color};}}"
         )
 
     def choose_sidebar_color(self):
@@ -2138,10 +2142,14 @@ class SettingsDialog(QtWidgets.QDialog):
         c1 = self._grad_color1.name()
         c2 = self._grad_color2.name()
         self.btn_grad1.setStyleSheet(
-            f"QPushButton{{background:{c1}; border:1px solid #555;}} QPushButton:hover{{background:{c1};}}"
+            f"QPushButton{{background:{c1}; border:1px solid #555;}} "
+            f"QPushButton:hover{{background:{c1};}} "
+            f"QPushButton:focus{{background:{c1};}}"
         )
         self.btn_grad2.setStyleSheet(
-            f"QPushButton{{background:{c2}; border:1px solid #555;}} QPushButton:hover{{background:{c2};}}"
+            f"QPushButton{{background:{c2}; border:1px solid #555;}} "
+            f"QPushButton:hover{{background:{c2};}} "
+            f"QPushButton:focus{{background:{c2};}}"
         )
 
     def choose_grad_color(self, idx):


### PR DESCRIPTION
## Summary
- add focus-state background styling alongside the existing hover rule for the workspace, sidebar, and gradient color buttons
- ensure both gradient color buttons receive the same focus styling as their counterparts

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8772f4f4083328b43bd85a2d410a0