### PR TITLE
Refresh neon effect configuration updates

### DIFF
--- a/app/effects.py
+++ b/app/effects.py
@@ -230,6 +230,8 @@ def update_neon_filters(root: QtWidgets.QWidget, config: dict) -> None:
             if hasattr(widget, "viewport"):
                 widget.viewport().installEventFilter(filt)
             widget._neon_filter = filt
+        elif enabled and filt is not None:
+            filt._config = config
         elif not enabled and filt is not None:
             try:
                 widget.removeEventFilter(filt)

--- a/app/main.py
+++ b/app/main.py
@@ -2470,8 +2470,9 @@ class MainWindow(QtWidgets.QMainWindow):
             apply_neon_effect(b, False, config=CONFIG)
 
     def _on_settings_changed(self):
-        global CONFIG, BASE_SAVE_PATH
-        CONFIG = load_config()
+        global BASE_SAVE_PATH
+        CONFIG.clear()
+        CONFIG.update(load_config())
         config.CONFIG = CONFIG
         if not isinstance(CONFIG.get("gradient_colors"), list):
             CONFIG["gradient_colors"] = ["#39ff14", "#2d7cdb"]


### PR DESCRIPTION
## Summary
- update existing neon event filters with the latest configuration when neon highlighting stays enabled
- reload the shared CONFIG mapping in place after settings changes and refresh the exported reference

## Testing
- pytest *(fails: ImportError: libGL.so.1 missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c87877def8833294c0f0b85e7543e8