### PR TITLE
Reset neon effect on calendar cell containers

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1461,10 +1461,12 @@ class ExcelCalendarTable(QtWidgets.QTableWidget):
         self.date_map.clear()
         self.cell_tables.clear()
         self.day_labels.clear()
+        for container in list(self.cell_containers.values()):
+            apply_neon_effect(container, False, config=CONFIG)
         self.cell_containers.clear()
         self.cell_filters.clear()
         self.setRowCount(len(weeks))
-        base_style = "border:1px solid transparent;"
+        base_style = "border:1px solid transparent; border-radius:8px;"
         for r, week in enumerate(weeks):
             for c, day in enumerate(week):
                 container = QtWidgets.QWidget()


### PR DESCRIPTION
## Summary
- reset neon highlights on existing calendar cell containers before rebuilding the grid for a new month
- update the base style for calendar day containers to include rounded borders

## Testing
- pytest *(fails: missing libGL.so.1 in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c87a3b9d50833284db01e8c56c8fa8