### PR TITLE
Ensure calendar cell hover styling uses neon filters

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1522,6 +1522,8 @@ class ExcelCalendarTable(QtWidgets.QTableWidget):
             for r, week in enumerate(weeks):
                 for c, day in enumerate(week):
                     container = QtWidgets.QWidget()
+                    container.setAttribute(QtCore.Qt.WA_Hover, True)
+                    container.setFocusPolicy(QtCore.Qt.NoFocus)
                     lay = QtWidgets.QVBoxLayout(container)
                     lay.setContentsMargins(0, 0, 0, 0)
                     lay.setSpacing(2)
@@ -1573,6 +1575,7 @@ class ExcelCalendarTable(QtWidgets.QTableWidget):
                     )
                     inner.itemChanged.connect(handler)
                     inner._autosave_handler = handler  # type: ignore[attr-defined]
+            update_neon_filters(self, CONFIG)
         finally:
             self._loading_cells = False
         self._update_row_heights()
@@ -1611,6 +1614,7 @@ class ExcelCalendarTable(QtWidgets.QTableWidget):
             f"QTableWidget{{background-color:{ws};color:{text_color};}}"
             f"QTableWidget::item{{background-color:{ws};color:{text_color};}}"
             f"QTableWidget::item:selected{{background-color:{ws};color:{text_color};}}"
+            "QTableWidget::item:hover{border:1px solid transparent;}"
         )
         self.setStyleSheet(style)
         self.horizontalHeader().setStyleSheet(f"background-color:{ws};")


### PR DESCRIPTION
## Summary
- enable hover support and disable focus for newly created calendar day containers
- refresh neon event filters after repopulating the month grid so new widgets receive neon borders
- suppress the default table hover outline to keep the custom rounded neon hover appearance

## Testing
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68c95e1476848332be26129af8ed0822