### PR TITLE
Add optional border control to neon effect

### DIFF
--- a/app/effects.py
+++ b/app/effects.py
@@ -66,6 +66,7 @@ def apply_neon_effect(
     widget: QtWidgets.QWidget,
     on: bool = True,
     shadow: bool = True,
+    border: bool = True,
     *,
     config: dict | None = None,
 ) -> None:
@@ -83,6 +84,10 @@ def apply_neon_effect(
         is applied.  Set to ``False`` to skip the drop shadow, keeping only the
         color adjustments.  This is useful for widgets like ``QLabel`` where the
         shadow is visually undesirable.
+    border: bool
+        When ``True`` (default) a colored border matching the highlight color is
+        added to the widget.  Set to ``False`` to leave the widget border
+        unchanged.
     """
 
     if widget is None or not shiboken6.isValid(widget):
@@ -135,7 +140,10 @@ def apply_neon_effect(
                 return
         else:
             widget.setGraphicsEffect(None)
-        border_style = f" border:{thickness}px solid {color.name()};"
+        if border:
+            border_style = f" border:{thickness}px solid {color.name()};"
+        else:
+            border_style = ""
         text_style = f" color:{color.name()};"
         widget.setStyleSheet(prev_style + text_style + border_style)
         widget._neon_effect = eff

--- a/app/main.py
+++ b/app/main.py
@@ -2353,7 +2353,9 @@ class TopBar(QtWidgets.QWidget):
             style = "QLabel{color:#e5e5e5; border:none;}"
             self.setStyleSheet(style)
             self.apply_background(self.palette().color(QtGui.QPalette.Window))
-            apply_neon_effect(self.lbl_month, True, config=CONFIG)
+            apply_neon_effect(
+                self.lbl_month, True, shadow=False, border=False, config=CONFIG
+            )
         else:
             if CONFIG.get("theme", "dark") == "dark":
                 style = self.default_style


### PR DESCRIPTION
## Summary
- add a configurable `border` flag to `apply_neon_effect` so neon styling can skip the highlight border
- apply the new flag in `TopBar.apply_style` to keep the month label borderless when neon is enabled

## Testing
- python -m pytest tests/test_neon_effect.py *(fails: ImportError: libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68c96cdeec248332bfe9668bc4b99f06