### PR TITLE
Preserve spin box radius when neon border applied

### DIFF
--- a/app/effects.py
+++ b/app/effects.py
@@ -1,3 +1,5 @@
+import re
+
 from PySide6 import QtWidgets, QtGui, QtCore
 import shiboken6
 import weakref
@@ -111,6 +113,12 @@ def apply_neon_effect(
         if getattr(widget, "_neon_prev_style", None) is None:
             widget._neon_prev_style = widget.styleSheet()
         prev_style = widget._neon_prev_style or ""
+        border_radius_style = ""
+        if prev_style:
+            matches = re.findall(r"border-radius\s*:\s*[^;]+", prev_style, re.IGNORECASE)
+            if matches:
+                border_radius_value = matches[-1].strip()
+                border_radius_style = f" {border_radius_value.rstrip(';')};"
         color = widget.palette().color(QtGui.QPalette.Highlight)
         eff = None
         blur_radius = 20
@@ -145,7 +153,7 @@ def apply_neon_effect(
         else:
             border_style = ""
         text_style = f" color:{color.name()};"
-        widget.setStyleSheet(prev_style + text_style + border_style)
+        widget.setStyleSheet(prev_style + text_style + border_style + border_radius_style)
         widget._neon_effect = eff
     else:
         prev = getattr(widget, "_neon_prev_effect", None)

--- a/app/main.py
+++ b/app/main.py
@@ -2336,8 +2336,13 @@ class TopBar(QtWidgets.QWidget):
         self.lbl_month.setStyleSheet("background:transparent; border:none;")
         # Ensure rounded spin box with a semi-transparent border for contrast
         self.spin_year.setStyleSheet(
-            f"background-color:{qcolor.name()}; padding:0 4px;"
-            " border-radius:6px; border:1px solid rgba(255,255,255,0.2);"
+            (
+                "QSpinBox{"
+                f"background-color:{qcolor.name()}; padding:0 4px;"
+                " border-radius:6px; border:1px solid rgba(255,255,255,0.2);"
+                "}"
+                " QSpinBox::lineEdit{border-radius:6px;}"
+            )
         )
         self.apply_fonts()
 


### PR DESCRIPTION
## Summary
- preserve the original border-radius when enabling neon highlights by reapplying the stored radius value
- update the top bar year spin box stylesheet to extend its border-radius to the QSpinBox::lineEdit subcontrol

## Testing
- pytest *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68c96e0a0b008332b7c861f21f8b9214