### PR TITLE
Enable neon effects unconditionally

### DIFF
--- a/app/widgets.py
+++ b/app/widgets.py
@@ -2,7 +2,7 @@ import math
 
 from PySide6 import QtWidgets, QtGui, QtCore
 
-from effects import apply_neon_effect, neon_enabled
+from effects import apply_neon_effect
 from resources import icon
 from config import CONFIG
 
@@ -87,16 +87,14 @@ class ButtonStyleMixin:
     def enterEvent(self, event):  # noqa: D401
         self._apply_hover(True)
         self._neon_prev_style = self.styleSheet()
-        if neon_enabled(CONFIG):
-            apply_neon_effect(self, True, config=CONFIG)
+        apply_neon_effect(self, True, config=CONFIG)
         super().enterEvent(event)
 
     def leaveEvent(self, event):  # noqa: D401
         selected = bool(self.property("neon_selected"))
         self._apply_hover(selected)
         self._neon_prev_style = self.styleSheet()
-        if neon_enabled(CONFIG):
-            apply_neon_effect(self, selected, config=CONFIG)
+        apply_neon_effect(self, selected, config=CONFIG)
         super().leaveEvent(event)
 
 

--- a/tests/test_accent_color_update.py
+++ b/tests/test_accent_color_update.py
@@ -21,7 +21,7 @@ def test_sidebar_updates_on_accent_change(monkeypatch):
 
     calls = []
 
-    def fake_apply_style(self, neon, accent, sidebar_color):
+    def fake_apply_style(self, accent, sidebar_color):
         # record the accent and palette highlight at call time
         highlight = QtWidgets.QApplication.instance().palette().color(
             QtGui.QPalette.Highlight


### PR DESCRIPTION
## Summary
- default the configuration to neon highlighting and always install neon event filters
- simplify the settings dialog to remove the neon toggle while keeping size, thickness and intensity controls
- update sidebar, top bar, and main window styling plus widgets/tests to assume neon is always enabled

## Testing
- `pytest` *(fails: missing libGL.so.1 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca519bde288332a682daafd7892358