### PR TITLE
Enable neon by default and migrate configs

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -35,7 +35,7 @@ _OLD_DAY_ROWS_DEFAULT = 6
 
 def load_config():
     default = {
-        "neon": False,
+        "neon": True,
         "neon_size": 10,
         "neon_thickness": 1,
         "neon_intensity": 255,
@@ -70,6 +70,11 @@ def load_config():
             if day_rows is None or day_rows == _OLD_DAY_ROWS_DEFAULT:
                 data["day_rows"] = DAY_ROWS_DEFAULT
                 migrated = True
+
+            neon_enabled = data.get("neon")
+            if not neon_enabled:
+                data["neon"] = True
+                migrated = True
             default.update({k: v for k, v in data.items() if v is not None})
             for key in ("monochrome", "mono_saturation", "theme"):
                 default.pop(key, None)
@@ -85,6 +90,7 @@ def load_config():
     else:
         try:
             os.makedirs(os.path.dirname(CONFIG_PATH), exist_ok=True)
+            default["neon"] = True
             with open(CONFIG_PATH, "w", encoding="utf-8") as f:
                 json.dump(default, f, ensure_ascii=False, indent=2)
         except Exception:

--- a/tests/test_settings_default_font.py
+++ b/tests/test_settings_default_font.py
@@ -10,6 +10,14 @@ from PySide6 import QtWidgets
 import app.main as main
 
 
+def test_load_config_creates_neon_enabled_config(tmp_path):
+    main.CONFIG_PATH = str(tmp_path / "config.json")
+    main.CONFIG = main.load_config()
+    main.config.CONFIG = main.CONFIG
+
+    assert main.CONFIG["neon"] is True
+
+
 def test_settings_dialog_uses_exo2_by_default(tmp_path):
     main.CONFIG_PATH = str(tmp_path / "config.json")
     main.CONFIG = main.load_config()


### PR DESCRIPTION
## Summary
- set the default configuration to enable neon and persist the flag when creating a new file
- migrate existing configuration files so the neon flag is added or forced to true when absent or disabled
- add a regression test ensuring a freshly created configuration returns neon enabled

## Testing
- `pytest` *(fails: missing libGL.so.1 required by PySide6)*

------
https://chatgpt.com/codex/tasks/task_e_68ca59914f0483329d2490467ceda3f6